### PR TITLE
Add Metadata Support

### DIFF
--- a/dotbot/dispatcher.py
+++ b/dotbot/dispatcher.py
@@ -46,9 +46,9 @@ class Dispatcher(object):
             for plugin in Executor.__subclasses__()]
 
     def _handle_metadata(self, metadata):
+        print
         if 'title' in metadata:
             self._log.warning(metadata['title'])
-
         if 'description' in metadata:
             self._log.info(' ' + metadata['description'])
 


### PR DESCRIPTION
While using Dotbot, I've found that adding metadata could be very helpful, not only when seeing what's being installed or failing, but when providing documentation about the action JSON as well.

So, I've added metadata support into configuration files. It works by reading for a `meta` key and handling this dict separately. 

The `meta` key is completely optional, and causes no difference in functionality if not found. If it is found, it currently this supports the `title` and `description` keys. Title prints a "warning" to the log, while description prints "info" to the log, indented by a space.

This feature supports `-q` and `-Q` as well. `-q` will print titles and descriptions, while `-Q` will only print the titles.
##### Example

```
[
    {
        "link": {
            "~/.aliases": "other/aliases",
            "~/.fonts": "fonts",
            "~/.zsh-update": "other/zsh-update"
        },
        "meta": {
            "description": "Files which don't fit anywhere else",
            "title": "Other"
        }
    },
...
```

Notice the `meta` key doesn't need to be the first in the task.

```
./install.sh 

Other
 Files which don't fit anywhere else
Link exists ~/.fonts -> /home/chris/dotfiles/fonts
Link exists ~/.zsh-update -> /home/chris/dotfiles/other/zsh-update
Link exists ~/.aliases -> /home/chris/dotfiles/other/aliases
All links have been set up
...
```

```
./install.sh -q

Other
 Files which don't fit anywhere else
All links have been set up
...
```

```
./install.sh -Q

Other
```
