### PR TITLE
Ignoring dirty pyyaml submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "lib/pyyaml"]
 	path = lib/pyyaml
 	url = https://github.com/anishathalye/pyyaml
+	ignore = dirty


### PR DESCRIPTION
When used, pyyaml generates `*.pyc` files, which will cause it to appear as dirty.  This will bubble all the way up to the owning dotfile repository.  This change should make it so that running a dotfile install script will not cause any repo-level changes by default.
