### PR TITLE
Fixing version check

### DIFF
--- a/bin/dotbot
+++ b/bin/dotbot
@@ -10,7 +10,7 @@ def inject(lib_path):
     sys.path.insert(0, path)
 
 # version dependent libraries
-if sys.version_info.major >= 3:
+if sys.version_info[0] >= 3:
     inject('pyyaml/lib3')
 else:
     inject('pyyaml/lib')


### PR DESCRIPTION
On python 2.6, the version check fails because of the following error:

```
Traceback (most recent call last):
  File "/home/lbriggs/dotfiles/dotbot/bin/dotbot", line 13, in <module>
    if sys.version_info.major >= 3:
AttributeError: 'tuple' object has no attribute 'major'
```

It seems that according to many python apps I've found such as here:
https://github.com/piskvorky/gensim/commit/472a3d11a0fc240d4756bd1daa08d2957b897ba4
and here:
https://github.com/astraw/stdeb/issues/79

A better way to figure out the version is to use the function in this PR.

This gets everything working nicely
