### PR TITLE
Provide exception information to help debug issues when reading the conf

### DIFF
--- a/dotbot/config.py
+++ b/dotbot/config.py
@@ -9,8 +9,8 @@ class ConfigReader(object):
             with open(config_file_path) as fin:
                 data = yaml.load(fin)
             return data
-        except Exception:
-            raise ReadingError('Could not read config file')
+        except Exception as e:
+            raise ReadingError('Could not read config file:\n%s' % e)
 
     def get_config(self):
         return self._config


### PR DESCRIPTION
When getting started I had a few typos in my YAML something like this would have helped pinpoint the error quickly instead of digging into the source to print stuff to see where the issue was. 

We can also remove the `ReadingError` completely since it doesn't really provide any helpful information to fix the issue. 
