### PR TITLE
Handle force creation of symlinked directories

### DIFF
--- a/dotbot/executor/linker.py
+++ b/dotbot/executor/linker.py
@@ -78,7 +78,9 @@ class Linker(Executor):
                 (self._exists(path) and not self._is_link(path))):
             fullpath = os.path.expanduser(path)
             try:
-                if os.path.isdir(fullpath):
+                if os.path.islink(fullpath):
+                    os.unlink(fullpath)
+                elif os.path.isdir(fullpath):
                     shutil.rmtree(fullpath)
                 else:
                     os.remove(fullpath)


### PR DESCRIPTION
Check if entry to force-create (delete) is a symlink and if so, simply
unlink it. Don't try to run rmtree on the underlying directory, which
will fail anyway.

Addresses issue #32.