### PR TITLE
Ability to use environment variables in link paths

### DIFF
--- a/dotbot/cli.py
+++ b/dotbot/cli.py
@@ -1,3 +1,5 @@
+import os
+import socket
 from argparse import ArgumentParser
 from .config import ConfigReader, ReadingError
 from .dispatcher import Dispatcher, DispatchError
@@ -24,6 +26,8 @@ def read_config(config_file):
 
 def main():
     log = Messenger()
+
+    os.environ.setdefault("HOSTNAME", socket.gethostname())
     try:
         parser = ArgumentParser()
         add_options(parser)

--- a/dotbot/executor/linker.py
+++ b/dotbot/executor/linker.py
@@ -107,7 +107,7 @@ class Linker(Executor):
         Returns true if successfully linked files.
         '''
         success = False
-        source = os.path.join(self._base_directory, source)
+        source = os.path.expandvars(os.path.join(self._base_directory, source))
         if (not self._exists(link_name) and self._is_link(link_name) and
                 self._link_destination(link_name) != source):
             self._log.warning('Invalid link %s -> %s' %


### PR DESCRIPTION
 Added the ability to use environment variables in link paths, and set up the HOSTNAME environment variable if it isn't already set. This makes linking host specific configs very easy by hostname, and leaves the potential to use other environment variables in the paths.

For example:
```yaml
- link:
    ~/.gitconfig: host/$HOSTNAME/gitconfig
```

Feel free to use or not, works well for my use case. 