### PR TITLE
Realize not everybody has bash

### DIFF
--- a/tools/git-submodule/install
+++ b/tools/git-submodule/install
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set -e
 

--- a/tools/hg-subrepo/install
+++ b/tools/hg-subrepo/install
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set -e
 


### PR DESCRIPTION
OpenBSD does not come with `bash` by default. Rather than `pkg_add` it, I chose to correct the scripts so as to not require it when the scripts function just as well with `sh`.