### PR TITLE
Load configuration file in order

### DIFF
--- a/dotbot/config.py
+++ b/dotbot/config.py
@@ -1,5 +1,24 @@
 import yaml
 from .util import string
+from collections import OrderedDict
+
+
+def ordered_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
+    """ Stolen from SO - http://stackoverflow.com/questions/5121931/in-python-how-can-you-load-yaml-mappings-as-ordereddicts
+
+    Loads a YAML file using an OrderedDict so the ordering of the values are
+    maintained
+    """
+    class OrderedLoader(Loader):
+        pass
+    def construct_mapping(loader, node):
+        loader.flatten_mapping(node)
+        return object_pairs_hook(loader.construct_pairs(node))
+    OrderedLoader.add_constructor(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        construct_mapping)
+    return yaml.load(stream, OrderedLoader)
+
 
 class ConfigReader(object):
     def __init__(self, config_file_path):
@@ -8,7 +27,7 @@ class ConfigReader(object):
     def _read(self, config_file_path):
         try:
             with open(config_file_path) as fin:
-                data = yaml.load(fin)
+                data = ordered_load(fin)
             return data
         except Exception as e:
             msg = string.indent_lines(str(e))

--- a/test/tests/config-ordered.bash
+++ b/test/tests/config-ordered.bash
@@ -1,0 +1,26 @@
+test_description='config loaded in order'
+. '../test-lib.bash'
+
+test_expect_success 'setup' '
+mkdir ${DOTFILES}/a &&
+mkdir ${DOTFILES}/b &&
+mkdir ${DOTFILES}/c
+echo "orange" > ${DOTFILES}/d
+'
+
+test_expect_success 'run' '
+run_dotbot <<EOF
+- link:
+    ~/.a: a
+    ~/.a/b: b
+    ~/.a/b/c: c
+    ~/.a/b/c/d: d
+EOF
+'
+
+test_expect_success 'test' '
+test -d ~/.a &&
+test -d ~/.a/b &&
+test -d ~/.a/b/c &&
+grep "orange" ~/.a/b/c/d
+'


### PR DESCRIPTION
I have a use case where it is important that links are created in the order that listed, e.g.

```
- link:
    ~/.pyenv: contrib/pyenv
    ~/.pyenv/plugins/pyenv-virtualenv: contrib/pyenv-virtualenv
```
This way I don't have to modify the pyenv submodule to add pyenv-virtualenv as a submodule to it.

I've implemented this by having pyyaml load using an OrderedDict rather than a dict. I also added a test that I confirmed will fail with the default loading. 