### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+
+script:
+  - ./.travis/run_tests

--- a/.travis/run_tests
+++ b/.travis/run_tests
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -e
+
+# For debug only:
+# export DEBUG=true
+# set -x
+# set -v
+
+BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Travis runs do not rely on Vagrant
+export USE_VAGRANT=false
+export DOTBOT_EXEC="${BASEDIR}/bin/dotbot"
+
+cd "${BASEDIR}"
+. "test/driver-lib.bash"
+
+travis_initialize() {
+    echo "initializing."
+    tests_run=0
+    tests_passed=0
+    tests_failed=0
+    tests_total="${1}"
+    local plural="" && [ "${tests_total}" -gt 1 ] && plural="s"
+    printf -- "running %d test%s...\n\n" "${tests_total}" "${plural}"
+}
+
+travis_cleanup() {
+    # Remove all dotfiles installed since the start, ignoring the main
+    # dotfiles directory, and the dotbot source directory
+    find ~ -mindepth 1 -readable -newermt "${date_stamp}" \
+        -not \( -path ~ -o -path "${BASEDIR}/*" \
+                -o -path ~/dotfiles \) \
+        -exec rm -rf {} +
+}
+
+travis_run_test() {
+    tests_run=$((tests_run + 1))
+    printf '[%d/%d] (%s)\n' "${tests_run}" "${tests_total}" "${1}"
+    cd ${BASEDIR}/test/tests
+    if bash ${1} ; then
+        pass
+    else
+        fail
+    fi
+    travis_cleanup || die "unable to clean up system."
+}
+
+date_stamp="$(date --rfc-3339=ns)"
+start="$(date +%s)"
+
+declare -a tests=()
+
+if [ $# -eq 0 ]; then
+    while read file; do
+        tests+=("${file}")
+    done < <(find ${BASEDIR}/test/tests -type f -name '*.bash')
+else
+    tests=("$@")
+fi
+
+travis_initialize "${#tests[@]}"
+
+for file in "${tests[@]}"; do
+    travis_run_test "$(basename "${file}")"
+done
+
+if report; then
+    ret=0
+else
+    ret=1
+fi
+
+echo "(tests run in $(($(date +%s) - start)) seconds)"
+exit ${ret}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Dotbot makes installing your dotfiles as easy as `git clone $url && cd dotfiles
 
 ---
 
+[![Build Status](https://travis-ci.org/anishathalye/dotbot.svg?branch=master)](https://travis-ci.org/anishathalye/dotbot)
+
 Dotbot is a tool that bootstraps your dotfiles (it's a [Dot]files
 [bo]o[t]strapper, get it?). It does *less* than you think, because version
 control systems do more than you think.

--- a/test/test-lib.bash
+++ b/test/test-lib.bash
@@ -1,5 +1,7 @@
-DEBUG=false
-DOTFILES='/home/vagrant/dotfiles'
+DEBUG=${DEBUG:-false}
+USE_VAGRANT=${USE_VAGRANT:-true}
+DOTBOT_EXEC=${DOTBOT_EXEC:-"/dotbot/bin/dotbot"}
+DOTFILES="/home/$(whoami)/dotfiles"
 INSTALL_CONF='install.conf.yaml'
 INSTALL_CONF_JSON='install.conf.json'
 
@@ -35,7 +37,9 @@ check_vm() {
 }
 
 initialize() {
-    check_vm
+    if ${USE_VAGRANT}; then
+        check_vm
+    fi
     echo "${test_description}"
     mkdir -p "${DOTFILES}"
     cd
@@ -45,7 +49,7 @@ run_dotbot() {
     (
         cd "${DOTFILES}"
         cat > "${INSTALL_CONF}"
-        /dotbot/bin/dotbot -d . -c "${INSTALL_CONF}" "${@}"
+        ${DOTBOT_EXEC} -d . -c "${INSTALL_CONF}" "${@}"
     )
 }
 
@@ -53,7 +57,7 @@ run_dotbot_json() {
     (
         cd "${DOTFILES}"
         cat > "${INSTALL_CONF_JSON}"
-        /dotbot/bin/dotbot -d . -c "${INSTALL_CONF_JSON}" "${@}"
+        ${DOTBOT_EXEC} -d . -c "${INSTALL_CONF_JSON}" "${@}"
     )
 }
 


### PR DESCRIPTION
This implements Travis CI support (see #67).

- Use the current Bash test suite.
- Add the possibility to run the test suite without Vagrant. Since on Travis, breaking the system is not an issue, I use a cleanup function instead. It merely removes files created after the start of the test suite. Since there is nothing besides the tests happening on the system, it should be good enough. Of course, that's something that should not be done on an actual system...
- Use the container-based infrastructure (`sudo` is not needed).
- Example of successful build available [here](https://travis-ci.org/bchretien/dotbot/builds/102755162). I also made a dummy commit breaking a test [there](https://travis-ci.org/bchretien/dotbot/builds/102755980).
- I haven't tested the Vagrant build locally with this commit, so it should probably be done before merging.