### PR TITLE
Travis: minor improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,7 @@ python:
   - "3.4"
   - "3.5"
 
+sudo: false
+
 script:
   - ./test/test_travis

--- a/test/test_travis
+++ b/test/test_travis
@@ -8,6 +8,12 @@ set -e
 
 BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# Prevent execution outside of Travis CI builds
+if [[ "${TRAVIS}" != true || "${CI}" != true ]]; then
+    echo "Error: `basename "$0"` should only be used on Travis"
+    exit 2
+fi
+
 # Travis runs do not rely on Vagrant
 export USE_VAGRANT=false
 export DOTBOT_EXEC="${BASEDIR}/bin/dotbot"


### PR DESCRIPTION
This PR contains minor improvements for #68.

- Force the use of the container-based infrastructure. According to their doc, I assumed that would be the case by default, but apparently not:

> For repos we recognize before 2015-01-01, linux builds are sent to our standard infrastructure.
> For repos we recognize on or after 2015-01-01, linux builds are sent to our container-based infrastructure.

- Since the test script for Travis is now in the `test` directory, I added a check to prevent running it outside of Travis. It depends on [their environment variables](https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables).