### PR TITLE
Directive plugins

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 =====================
 
-**Copyright (c) 2014-2015 Anish Athalye (me@anishathalye.com)**
+**Copyright (c) 2014-2016 Anish Athalye (me@anishathalye.com)**
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Do you have a feature request, bug report, or patch? Great! See
 License
 -------
 
-Copyright (c) 2014-2015 Anish Athalye. Released under the MIT License. See
+Copyright (c) 2014-2016 Anish Athalye. Released under the MIT License. See
 [LICENSE.md][license] for details.
 
 [init-dotfiles]: https://github.com/Aviator45003/init-dotfiles

--- a/dotbot/__init__.py
+++ b/dotbot/__init__.py
@@ -1,1 +1,2 @@
 from .cli import main
+from .plugin import Plugin

--- a/dotbot/cli.py
+++ b/dotbot/cli.py
@@ -1,8 +1,11 @@
+import os, glob
+
 from argparse import ArgumentParser
 from .config import ConfigReader, ReadingError
 from .dispatcher import Dispatcher, DispatchError
 from .messenger import Messenger
 from .messenger import Level
+from .util import module
 
 def add_options(parser):
     parser.add_argument('-Q', '--super-quiet', dest='super_quiet', action='store_true',
@@ -17,6 +20,12 @@ def add_options(parser):
     parser.add_argument('-c', '--config-file', nargs=1, dest='config_file',
         help='run commands given in CONFIGFILE', metavar='CONFIGFILE',
         required=True)
+    parser.add_argument('-p', '--plugin', action='append', dest='plugins', default=[],
+        help='load PLUGIN as a plugin', metavar='PLUGIN')
+    parser.add_argument('--disable-built-in-plugins', dest='disable_built_in_plugins',
+        action='store_true', help='disable built-in plugins')
+    parser.add_argument('--plugin-dir', action='append', dest='plugin_dirs', default=[],
+        metavar='PLUGIN_DIR', help='load all plugins in PLUGIN_DIR')
 
 def read_config(config_file):
     reader = ConfigReader(config_file)
@@ -28,12 +37,24 @@ def main():
         parser = ArgumentParser()
         add_options(parser)
         options = parser.parse_args()
-        if (options.super_quiet):
+        if options.super_quiet:
             log.set_level(Level.WARNING)
-        if (options.quiet):
+        if options.quiet:
             log.set_level(Level.INFO)
-        if (options.verbose):
+        if options.verbose:
             log.set_level(Level.DEBUG)
+        plugin_directories = list(options.plugin_dirs)
+        if not options.disable_built_in_plugins:
+          plugin_directories.append(os.path.join(os.path.dirname(__file__), '..', 'plugins'))
+        plugin_paths = []
+        for directory in plugin_directories:
+          for plugin_path in glob.glob(os.path.join(directory, '*.py')):
+            plugin_paths.append(plugin_path)
+        for plugin_path in options.plugins:
+            plugin_paths.append(plugin_path)
+        for plugin_path in plugin_paths:
+            abspath = os.path.abspath(plugin_path)
+            module.load(plugin_path)
         tasks = read_config(options.config_file[0])
         if not isinstance(tasks, list):
             raise ReadingError('Configuration file must be a list of tasks')

--- a/dotbot/dispatcher.py
+++ b/dotbot/dispatcher.py
@@ -1,5 +1,5 @@
 import os
-from .executor import Executor
+from .plugin import Plugin
 from .messenger import Messenger
 
 class Dispatcher(object):
@@ -37,7 +37,7 @@ class Dispatcher(object):
 
     def _load_plugins(self):
         self._plugins = [plugin(self._base_directory)
-            for plugin in Executor.__subclasses__()]
+            for plugin in Plugin.__subclasses__()]
 
 class DispatchError(Exception):
     pass

--- a/dotbot/executor/__init__.py
+++ b/dotbot/executor/__init__.py
@@ -1,4 +1,0 @@
-from .executor import Executor
-from .linker import Linker
-from .cleaner import Cleaner
-from .commandrunner import CommandRunner

--- a/dotbot/plugin.py
+++ b/dotbot/plugin.py
@@ -1,6 +1,6 @@
-from ..messenger import Messenger
+from .messenger import Messenger
 
-class Executor(object):
+class Plugin(object):
     '''
     Abstract base class for commands that process directives.
     '''
@@ -11,7 +11,7 @@ class Executor(object):
 
     def can_handle(self, directive):
         '''
-        Returns true if the Executor can handle the directive.
+        Returns true if the Plugin can handle the directive.
         '''
         raise NotImplementedError
 
@@ -19,6 +19,6 @@ class Executor(object):
         '''
         Executes the directive.
 
-        Returns true if the Executor successfully handled the directive.
+        Returns true if the Plugin successfully handled the directive.
         '''
         raise NotImplementedError

--- a/dotbot/util/module.py
+++ b/dotbot/util/module.py
@@ -1,0 +1,29 @@
+import sys, os.path
+
+# We keep references to loaded modules so they don't get garbage collected.
+loaded_modules = []
+
+def load(path):
+  basename = os.path.basename(path)
+  module_name, extension = os.path.splitext(basename)
+  plugin = load_module(module_name, path)
+  loaded_modules.append(plugin)
+
+if sys.version_info >= (3, 5):
+  import importlib.util, os.path
+
+  def load_module(module_name, path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+elif sys.version_info >= (3, 3):
+  from importlib.machinery import SourceFileLoader
+
+  def load_module(module_name, path):
+    return SourceFileLoader(module_name, path).load_module()
+else:
+  import imp
+
+  def load_module(module_name, path):
+    return imp.load_source(module_name, path)

--- a/plugins/clean.py
+++ b/plugins/clean.py
@@ -1,7 +1,6 @@
-import os
-from . import Executor
+import os, dotbot
 
-class Cleaner(Executor):
+class Clean(dotbot.Plugin):
     '''
     Cleans broken symbolic links.
     '''
@@ -13,7 +12,7 @@ class Cleaner(Executor):
 
     def handle(self, directive, data):
         if directive != self._directive:
-            raise ValueError('Cleaner cannot handle directive %s' % directive)
+            raise ValueError('Clean cannot handle directive %s' % directive)
         return self._process_clean(data)
 
     def _process_clean(self, targets):

--- a/plugins/link.py
+++ b/plugins/link.py
@@ -1,7 +1,6 @@
-import os, shutil
-from . import Executor
+import os, shutil, dotbot
 
-class Linker(Executor):
+class Link(dotbot.Plugin):
     '''
     Symbolically links dotfiles.
     '''
@@ -13,7 +12,7 @@ class Linker(Executor):
 
     def handle(self, directive, data):
         if directive != self._directive:
-            raise ValueError('Linker cannot handle directive %s' % directive)
+            raise ValueError('Link cannot handle directive %s' % directive)
         return self._process_links(data)
 
     def _process_links(self, links):

--- a/plugins/shell.py
+++ b/plugins/shell.py
@@ -1,7 +1,6 @@
-import os, subprocess
-from . import Executor
+import os, subprocess, dotbot
 
-class CommandRunner(Executor):
+class Shell(dotbot.Plugin):
     '''
     Run arbitrary shell commands.
     '''
@@ -13,7 +12,7 @@ class CommandRunner(Executor):
 
     def handle(self, directive, data):
         if directive != self._directive:
-            raise ValueError('CommandRunner cannot handle directive %s' %
+            raise ValueError('Shell cannot handle directive %s' %
                 directive)
         return self._process_commands(data)
 


### PR DESCRIPTION
Okay, after much delay, I have a PR for you that implements plugins.

I've tested it on 2.7, 3.2, 3.3, 3.4, and 3.5. I suspect it also works on 3.0 and 3.1.

I turned shell, link, and clean into plugins. So that the built in plugins are easy to find and understand, to encourage users to copy them and make their own, I put them in a top-level plugins folder, and renamed them so that they're just their directive name.

I changed the name of Executor to Plugin. It can be used from plugins as `from dobot import Plugin`, or `import dotbot` and the referred to as `dotbot.Plugin`.

Let me know if you'd like to me to make any changes.