### PR TITLE
Allow empty link sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,9 @@ symbolic link should have a relative path.
       path: zshrc
 ```
 
-If the source location is omitted or NULL, dotbot will use the destination instead, without a leading `.` if present. This makes the following three config files equivalent:
+If the source location is omitted or set to `null`, Dotbot will use the
+basename of the destination, with a leading `.` stripped if present. This makes
+the following three config files equivalent:
 
 ```yaml
 - link:

--- a/README.md
+++ b/README.md
@@ -189,6 +189,47 @@ symbolic link should have a relative path.
       path: zshrc
 ```
 
+If the source location is omitted or NULL, dotbot will use the destination instead, without a leading `.` if present. This makes the following three config files equivalent:
+
+```yaml
+- link:
+    ~/bin/ack: ack
+    ~/.vim: vim
+    ~/.vimrc:
+      relink: true
+      path: vimrc
+    ~/.zshrc:
+      force: true
+      path: zshrc
+```
+
+```yaml
+- link:
+    ~/bin/ack:
+    ~/.vim:
+    ~/.vimrc:
+      relink: true
+    ~/.zshrc:
+      force: true
+```
+
+```json
+[
+  {
+    "link": {
+      "~/bin/ack": null,
+      "~/.vim": null,
+      "~/.vimrc": {
+        "relink": true
+      },
+      "~/.zshrc": {
+        "force": true
+      }
+    }
+  }
+]
+```
+
 ### Shell
 
 Shell commands specify shell commands to be run. Shell commands are run in the

--- a/plugins/link.py
+++ b/plugins/link.py
@@ -47,14 +47,14 @@ class Link(dotbot.Plugin):
         return success
 
     def _default_source(self, destination, source):
-      if source == None:
-          basename = os.path.basename(destination)
-          if basename.startswith('.'):
-            return basename[1:]
-          else:
-            return basename
-      else:
-          return source
+        if source is None:
+            basename = os.path.basename(destination)
+            if basename.startswith('.'):
+                return basename[1:]
+            else:
+                return basename
+        else:
+            return source
 
     def _is_link(self, path):
         '''

--- a/plugins/link.py
+++ b/plugins/link.py
@@ -30,9 +30,9 @@ class Link(dotbot.Plugin):
                 force = source.get('force', force)
                 relink = source.get('relink', relink)
                 create = source.get('create', create)
-                path = source['path']
+                path = self._default_source(destination, source.get('path'))
             else:
-                path = source
+                path = self._default_source(destination, source)
             path = os.path.expandvars(os.path.expanduser(path))
             if create:
                 success &= self._create(destination)
@@ -45,6 +45,16 @@ class Link(dotbot.Plugin):
         else:
             self._log.error('Some links were not successfully set up')
         return success
+
+    def _default_source(self, destination, source):
+      if source == None:
+          basename = os.path.basename(destination)
+          if basename.startswith('.'):
+            return basename[1:]
+          else:
+            return basename
+      else:
+          return source
 
     def _is_link(self, path):
         '''

--- a/test/tests/link-default-source.bash
+++ b/test/tests/link-default-source.bash
@@ -1,0 +1,26 @@
+test_description='link uses destination if source is null'
+. '../test-lib.bash'
+
+test_expect_success 'setup' '
+echo "apple" > ${DOTFILES}/f &&
+echo "grape" > ${DOTFILES}/fd
+'
+
+test_expect_success 'run' '
+run_dotbot <<EOF
+- link:
+    ~/f:
+    ~/.f:
+    ~/fd:
+        force: false
+    ~/.fd:
+        force: false
+EOF
+'
+
+test_expect_success 'test' '
+grep "apple" ~/f &&
+grep "apple" ~/.f &&
+grep "grape" ~/fd &&
+grep "grape" ~/.fd
+'


### PR DESCRIPTION
Heyo!

Here's a diff which I'm a bit ambivalent about, but I thought I'd open a PR anyways.

It changes the link plugin to allow the source to be None. (In yaml, this means having no value, or having the value `~`.)

If the source for a link is null, it uses the basename of the destination. If the basename has a leading '.', it strips that.

So, for example, this:

```yaml
- link:
 ~/bin/git-last:           git-last
 ~/bin/backup:             backup
 ~/.zshrc:                 zshrc
 ~/.gitconfig:             gitconfig
```

Can just be:

```yaml
- link:
 ~/bin/git-last:
 ~/bin/backup:
 ~/.zshrc:
 ~/.gitconfig:
```

I'm ambivalent about this because although it does save some typing and make config files a little easier to write, it does introduce a bit of magic which is not immediately obvious.

What do you think?