### PR TITLE
Fix README link to list of users after wiki reorg

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Copyright (c) 2014-2017 Anish Athalye. Released under the MIT License. See
 
 [init-dotfiles]: https://github.com/Vaelatern/init-dotfiles
 [dotfiles-template]: https://github.com/anishathalye/dotfiles_template
-[inspiration]: https://github.com/anishathalye/dotbot/wiki/List-of-Dotbot-Users
+[inspiration]: https://github.com/anishathalye/dotbot/wiki/Users
 [managing-dotfiles-post]: http://www.anishathalye.com/2014/08/03/managing-your-dotfiles/
 [wiki]: https://github.com/anishathalye/dotbot/wiki
 [contributing]: CONTRIBUTING.md


### PR DESCRIPTION
wiki:List-of-Dotbot-Users -> wiki:Users