### PR TITLE
Implement globbing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,17 +165,22 @@ files if necessary. Environment variables in paths are automatically expanded.
 
 Link commands are specified as a dictionary mapping targets to source
 locations. Source locations are specified relative to the base directory (that
-is specified when running the installer). Directory names should *not* contain
-a trailing "/" character.
+is specified when running the installer). If linking directories, *do not* include a trailing slash.
 
 Link commands support an (optional) extended configuration. In this type of
 configuration, instead of specifying source locations directly, targets are
-mapped to extended configuration dictionaries. These dictionaries map `path` to
-the source path, specify `create` as `true` if the parent directory should be
-created if necessary, specify `relink` as `true` if incorrect symbolic links
-should be automatically overwritten, specify `force` as `true` if the file or
-directory should be forcibly linked, and specify `relative` as `true` if the
-symbolic link should have a relative path.
+mapped to extended configuration dictionaries.
+
+Available extended configuration parameters:
+
+| Link Option | Explanation |
+| -- | -- |
+| `path` | The target for the symlink, the same as in the shortcut syntax (default:null, automatic (see below)) |
+| `create` | When true, create parent directories to the link as needed. (default:false) |
+| `relink` | Removes the old target if it's a symlink (default:false) |
+| `force` | Force removes the old target, file or folder, and forces a new link (default:false) |
+| `relative` | Use a relative path when creating the symlink (default:false, absolute links) |
+| `use_glob` | Treat a `*` character as a wildcard, and perform link operations on all of those matches (default:false) |
 
 #### Example
 
@@ -207,6 +212,10 @@ the following three config files equivalent:
     ~/.zshrc:
       force: true
       path: zshrc
+    ~/.config/:
+      use_glob: true
+      path: config/*
+      relink: true
 ```
 
 ```yaml
@@ -217,6 +226,10 @@ the following three config files equivalent:
       relink: true
     ~/.zshrc:
       force: true
+    ~/.config/:
+      use_glob: true
+      path: config/*
+      relink: true
 ```
 
 ```json
@@ -230,6 +243,11 @@ the following three config files equivalent:
       },
       "~/.zshrc": {
         "force": true
+      },
+      "~/.config/": {
+        "use_glob": true,
+        "path": "config/*",
+        "relink": true
       }
     }
   }

--- a/dotbot/dispatcher.py
+++ b/dotbot/dispatcher.py
@@ -30,10 +30,11 @@ class Dispatcher(object):
                         try:
                             success &= plugin.handle(action, task[action])
                             handled = True
-                        except Exception:
+                        except Exception as err:
                             self._log.error(
                                 'An error was encountered while executing action %s' %
                                 action)
+                            self._log.debug(err)
                 if not handled:
                     success = False
                     self._log.error('Action %s not handled' % action)

--- a/plugins/link.py
+++ b/plugins/link.py
@@ -63,13 +63,15 @@ class Link(dotbot.Plugin):
                         success &= self._delete(path, destination, relative, force)
                     success &= self._link(path, destination, relative)
                 else:
-                    self._log.lowinfo("Linking globbed items: " + str(glob_results))
+                    self._log.lowinfo("Globs from '" + path + "': " + str(glob_results))
                     glob_base = path[:glob_star_loc]
                     for glob_full_item in glob_results:
                         glob_item = glob_full_item[len(glob_base):]
                         glob_link_destination = destination + glob_item
                         if create:
                             success &= self._create(glob_link_destination)
+                        if force or relink:
+                            success &= self._delete(glob_full_item, glob_link_destination, relative, force)
                         success &= self._link(glob_full_item, glob_link_destination, relative)
             else:
                 if create:


### PR DESCRIPTION
Phew! Turns out this does a lot better than I had initially planned!

I need help making the test cases, here's the behaviour I tried to create and need to test:

Failure cases
---
```yaml
link:
  ~/bin/:
    path: bin
    use_glob: true
```
```yaml
defaults:
  - link:
      use_glob: true
link:
  ~/bin/:
    path: bin/
```
Because we aren't sure if we should link `bin` inside `~/bin` or link `bin` *as* `~/bin`.
Handled with error message by the `glob_star_loc is -1 and destination[-1] is '/'` conditional.

Success Cases
---
```yaml
link:
  ~/bin:
    path: bin
    use_glob: true
```
```yaml
defaults:
  - link:
      use_glob: true
link:
  ~/bin:
    path: bin
```
Works as normal link operation `~/bin` -> `bin`, so that globbing can be turned on at default level.

```yaml
defaults:
  - link:
      use_glob: true
link:
  ~/bin/:
    path: bin/*
```
```yaml
link:
  ~/bin:
    path: bin/*
```
Links all the items in `bin/*` into individual links in `~/bin/`. So long as there is a wildcard `*` in the `path:` then it will link the glob results as individual items into the destination.

Trailing Slash
---
`~/bin` vs `~/bin/` is a special case used to enforce a certain behavior, with a trailing slash and `use_glob` enabled, it forces dotbot to treat the link task as "link items *into* this folder" instead of potentially linking *as*.

Advanced Quirks
---
```yaml
link:
  ~/.config/tmux/:
    path: tmux/**.conf
    create: true
```
Links all the `.conf` files in `tmux/` into `~/.config/tmux/` however the double star recursive match is not supported in python's default `glob`. (but is working in [glob2 pip package](https://pypi.python.org/pypi/glob2)
Example:
```
tmux
├── 2.1/
│   ├── bind-pane-zoom.conf -> ../bind-pane-zoom.conf
│   ├── keybinds-vi.conf -> ../keybinds-vi.conf
│   ├── mouse-mode-new.conf -> ../mouse-mode-new.conf
│   └── powerline-py3.conf -> ../powerline-py3.conf
├── 2.5/
│   ├── bind-pane-zoom.conf -> ../bind-pane-zoom.conf
│   ├── keybinds-vi.conf -> ../keybinds-vi.conf
│   ├── mouse-mode-new.conf -> ../mouse-mode-new.conf
│   └── powerline-py3.conf -> ../powerline-py3.conf
├── bind-pane-zoom.conf
├── keybinds-vi.conf
├── mouse-mode-new.conf
├── mouse-mode-old.conf
├── powerline-py3.conf
├── py2u.25.tmux.conf
└── tmux.conf
```
After link operation:
```
/home/robo/.config/tmux
├── bind-pane-zoom.conf -> /home/robo/code/configs/tmux/bind-pane-zoom.conf
├── keybinds-vi.conf -> /home/robo/code/configs/tmux/keybinds-vi.conf
├── mouse-mode-new.conf -> /home/robo/code/configs/tmux/mouse-mode-new.conf
├── mouse-mode-old.conf -> /home/robo/code/configs/tmux/mouse-mode-old.conf
├── powerline-py3.conf -> /home/robo/code/configs/tmux/powerline-py3.conf
├── py2u.25.tmux.conf -> /home/robo/code/configs/tmux/py2u.25.tmux.conf
└── tmux.conf -> /home/robo/code/configs/tmux/tmux.conf
```
Notice the folders were not linked. They could have been included as links by simply changing the glob link target to be `tmux/*` instead of `tmux/*.conf`.

If [glob2 was in use](https://github.com/miracle2k/python-glob2/), we could do recursive globs and make the glob match detection better.

I don't think we should bother including glob2 because I think this feature set covers all the use cases we are concerned about, and the cost of inclusion of another library is not worth the benefit here IMO.

Even without glob2, we can still do some interesting and more useful advanced things, like:
```yaml
link:
  ~/.config/:
    path: config/*/*
    create: true
```
This example creates normal directories for everything at the `~/.config/*` level, but then everything at the `~/.config/*/*` level is now a symlink.

Anyways,
---
I looked at the test setup, but it's a bit too cryptic for me to dive into tonight. Could someone else try making the test cases that match these?