### PR TITLE
[WIP] LinkIf shell conditionals

### DIFF
--- a/dotbot/dispatcher.py
+++ b/dotbot/dispatcher.py
@@ -34,7 +34,7 @@ class Dispatcher(object):
                             self._log.error(
                                 'An error was encountered while executing action %s' %
                                 action)
-                            self._log.debug(err)
+                            self._log.debug("Err: " + str(type(err)) + ": " + str(err))
                 if not handled:
                     success = False
                     self._log.error('Action %s not handled' % action)

--- a/dotbot/dispatcher.py
+++ b/dotbot/dispatcher.py
@@ -43,6 +43,7 @@ class Dispatcher(object):
     def _load_plugins(self):
         self._plugins = [plugin(self._context)
             for plugin in Plugin.__subclasses__()]
+        self._log.debug("Found plugins: " + str(self._plugins))
 
 class DispatchError(Exception):
     pass

--- a/plugins/link.py
+++ b/plugins/link.py
@@ -21,16 +21,16 @@ class Link(dotbot.Plugin):
         if directive != self._directive:
             raise ValueError('Link cannot handle directive %s' % directive)
         data_filtered = copy.deepcopy(data)
-        for destination, config in data_filtered.items():
-            if isinstance(config, dict) and self._config_if_key in config:
-                self._log.debug("testing conditional: %s" % config[self._config_if_key])
-                commandsuccess = self._test_success(config[self._config_if_key])
+        for d_key in list(data_filtered):
+            if isinstance(data_filtered[d_key], dict) and self._config_if_key in data_filtered[d_key]:
+                self._log.debug("testing conditional: %s" % data_filtered[d_key][self._config_if_key])
+                commandsuccess = self._test_success(data_filtered[d_key][self._config_if_key])
                 if commandsuccess:
                     # command successful, treat as normal link
-                    del data_filtered[destination][self._config_if_key]
+                    del data_filtered[d_key][self._config_if_key]
                 else:
                     # remove the item from data, we aren't going to link it
-                    del data_filtered[destination]
+                    del data_filtered[d_key]
 
         return self._process_links(data_filtered)
 


### PR DESCRIPTION
Still need to do:

- [ ] Check Python 2/3 compatibility
- [ ] Update docs
- [ ] Describe behaviour clearly
- [ ] Decide how verbose to be with the command stdout and stderr

Example yanked from my own configs: (using ZSH as my shell, commands are evaluated there)
```yaml
- linkif:
  # Conky
    ~/.conky/unseptium:
      if: 'conky --version && [[ $(hostname) == "robo-unseptium" ]]'
      create: false
      path: conky/unseptium
      force: true
  # TF2
    ~/unhexium/SteamLibrary/steamapps/common/Team Fortress 2/tf/cfg/:
      if: '[[ -d ~/unhexium/SteamLibrary/steamapps/common/Team\ Fortress\ 2 ]]'
      create: false # don't want this on non-gaming systems
      path: tf2/*
      glob: true
      force: true
```

Note carefully the use of single and double quotes, and escaping the spaces in paths. I'm not sure if we want to change anything about quoting or escaping levels, but it seems to work well for me.