### PR TITLE
Add `real_path` option to link command allow keeping source with symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Available extended configuration parameters:
 | `relink` | Removes the old target if it's a symlink (default:false) |
 | `force` | Force removes the old target, file or folder, and forces a new link (default:false) |
 | `relative` | Use a relative path to the source when creating the symlink (default:false, absolute links) |
+| `canonicalize-path` | Resolve any symbolic links encountered in the source to symlink to the canonical path (default:true, real paths) |
 | `glob` | Treat a `*` character as a wildcard, and perform link operations on all of those matches (default:false) |
 | `if` | Execute this in your `$SHELL` and only link if it is successful. |
 | `ignore-missing` | Do not fail if the source is missing and create the link anyway (default:false) |

--- a/dotbot/context.py
+++ b/dotbot/context.py
@@ -1,4 +1,5 @@
 import copy
+import os
 
 class Context(object):
     '''
@@ -13,8 +14,11 @@ class Context(object):
     def set_base_directory(self, base_directory):
         self._base_directory = base_directory
 
-    def base_directory(self):
-        return self._base_directory
+    def base_directory(self, canonical_path=True):
+        base_directory = self._base_directory
+        if canonical_path:
+            base_directory = os.path.realpath(base_directory)
+        return base_directory
 
     def set_defaults(self, defaults):
         self._defaults = defaults

--- a/dotbot/dispatcher.py
+++ b/dotbot/dispatcher.py
@@ -10,8 +10,8 @@ class Dispatcher(object):
         self._load_plugins()
 
     def _setup_context(self, base_directory):
-        path = os.path.abspath(os.path.realpath(
-            os.path.expanduser(base_directory)))
+        path = os.path.abspath(
+            os.path.expanduser(base_directory))
         if not os.path.exists(path):
             raise DispatchError('Nonexistent base directory')
         self._context = Context(path)


### PR DESCRIPTION
Note: This is one of two competing PRs which try to solve the same problem. It is open for discussion which one of those should be merged (or none of them). Ref: https://github.com/anishathalye/dotbot/pull/155. They where written in the order they where opened as PR. @ypid prefers this (#156) variant, because it allows greater flexibility and has no impact on any plugins because it only effects the link command.

dotbot had a hardcoded behaviour that the BASEDIR was always passed to
os.path.realpath which "returns the canonical path of the specified
filename, eliminating any symbolic links encountered in the path".

This might not always be desirable so this commit makes it configurable.

The use case where `real_path` comes in handy is the following:
You want to provide dotfiles in the Filesystem Hierarchy Standard under
`/usr/local/share/ypid_dotfiles/`. Now you want to provide
`.config/dotfiles` as a default in `/etc/skel`. When you now
pre-configure `/etc/skel` by running dotbot in it set has HOME, dotfiles
will refer to `/usr/local/share/ypid_dotfiles/` and not
`/etc/skel/.config/dotfiles` which does not look nice.

This is related to but not the same as the `relative` parameter used
with link commands.