### PR TITLE
Point PyYAML dependency to official repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "lib/pyyaml"]
 	path = lib/pyyaml
-	url = https://github.com/anishathalye/pyyaml
+	url = https://github.com/yaml/pyyaml
 	ignore = dirty

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -2,8 +2,7 @@ Vagrant.configure(2) do |config|
   config.vm.box = 'debian/stretch64'
 
   # sync by copying for isolation
-  config.vm.synced_folder "..", "/dotbot", type: "rsync",
-    rsync__exclude: ".git/"
+  config.vm.synced_folder "..", "/dotbot", type: "rsync"
 
   # disable default synced folder
   config.vm.synced_folder ".", "/vagrant", disabled: true

--- a/test/test-lib.bash
+++ b/test/test-lib.bash
@@ -1,10 +1,6 @@
 DEBUG=${DEBUG:-false}
 USE_VAGRANT=${USE_VAGRANT:-true}
-if ${USE_VAGRANT}; then
-    DOTBOT_EXEC=${DOTBOT_EXEC:-"python /dotbot/bin/dotbot"}
-else
-    DOTBOT_EXEC=${DOTBOT_EXEC:-"/dotbot/bin/dotbot"}
-fi
+DOTBOT_EXEC=${DOTBOT_EXEC:-"python /dotbot/bin/dotbot"}
 DOTFILES="/home/$(whoami)/dotfiles"
 INSTALL_CONF='install.conf.yaml'
 INSTALL_CONF_JSON='install.conf.json'

--- a/test/test_travis
+++ b/test/test_travis
@@ -6,7 +6,7 @@ set -e
 # set -x
 # set -v
 
-BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Prevent execution outside of Travis CI builds
 if [[ "${TRAVIS}" != true || "${CI}" != true ]]; then

--- a/test/tests/shim.bash
+++ b/test/tests/shim.bash
@@ -1,0 +1,29 @@
+test_description='install shim works'
+. '../test-lib.bash'
+
+test_expect_success 'setup' '
+cd ${DOTFILES}
+git init
+if ${USE_VAGRANT}; then
+    git submodule add /dotbot dotbot
+else
+    git submodule add ${BASEDIR} dotbot
+fi
+cp ./dotbot/tools/git-submodule/install .
+echo "pear" > ${DOTFILES}/foo
+'
+
+test_expect_success 'run' '
+cat > ${DOTFILES}/install.conf.yaml <<EOF
+- link:
+    ~/.foo: foo
+EOF
+if ! ${USE_VAGRANT}; then
+    sed -i "" "1 s/sh$/python/" ${DOTFILES}/dotbot/bin/dotbot
+fi
+${DOTFILES}/install
+'
+
+test_expect_success 'test' '
+grep "pear" ~/.foo
+'

--- a/tools/git-submodule/install
+++ b/tools/git-submodule/install
@@ -9,6 +9,7 @@ DOTBOT_BIN="bin/dotbot"
 BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 cd "${BASEDIR}"
+git -C "${DOTBOT_DIR}" submodule sync --recursive
 git submodule update --init --recursive "${DOTBOT_DIR}"
 
 "${BASEDIR}/${DOTBOT_DIR}/${DOTBOT_BIN}" -d "${BASEDIR}" -c "${CONFIG}" "${@}"


### PR DESCRIPTION
Previously, PyYAML was hosted on BitBucket, so we had a mirror of the
repo on GitHub. Now, official hosting has moved to GitHub, so we can
point to the official repository instead. Thanks to Marco A. Feliu
<marco.feliu@nianet.org> for pointing this out.

This patch also updates the install shim to update submodule URLs. To
preserve the functionality of earlier Dotbot versions, we will need to
maintain 'https://github.com/anishathalye/pyyaml'. Because old versions
of the install shim used with new Dotbot versions will not update
submodule URLs, we will need to keep the old repository in sync with the
upstream repository as we upgrade PyYAML versions.

This patch also upgrades the dependency to PyYAML 3.12.