### PR TITLE
Add option --no-color to suppress colorization of output

### DIFF
--- a/dotbot/cli.py
+++ b/dotbot/cli.py
@@ -28,6 +28,8 @@ def add_options(parser):
         action='store_true', help='disable built-in plugins')
     parser.add_argument('--plugin-dir', action='append', dest='plugin_dirs', default=[],
         metavar='PLUGIN_DIR', help='load all plugins in PLUGIN_DIR')
+    parser.add_argument('--no-color', dest='no_color', action='store_true',
+        help='disable color output')
     parser.add_argument('--version', action='store_true',
         help='show program\'s version number and exit')
 
@@ -50,6 +52,8 @@ def main():
             log.set_level(Level.INFO)
         if options.verbose:
             log.set_level(Level.DEBUG)
+        if options.no_color:
+            log.use_color(False)
         plugin_directories = list(options.plugin_dirs)
         if not options.disable_built_in_plugins:
             from .plugins import Clean, Link, Shell

--- a/dotbot/messenger/messenger.py
+++ b/dotbot/messenger/messenger.py
@@ -7,9 +7,13 @@ from .level import Level
 class Messenger(with_metaclass(Singleton, object)):
     def __init__(self, level = Level.LOWINFO):
         self.set_level(level)
+        self.use_color(True)
 
     def set_level(self, level):
         self._level = level
+
+    def use_color(self, yesno):
+        self._use_color = yesno
 
     def log(self, level, message):
         if (level >= self._level):
@@ -30,11 +34,14 @@ class Messenger(with_metaclass(Singleton, object)):
     def error(self, message):
         self.log(Level.ERROR, message)
 
+    def _should_use_color(self):
+        return self._use_color and sys.stdout.isatty()
+
     def _color(self, level):
         '''
         Get a color (terminal escape sequence) according to a level.
         '''
-        if not sys.stdout.isatty():
+        if not self._should_use_color():
             return ''
         elif level < Level.DEBUG:
             return ''
@@ -53,7 +60,7 @@ class Messenger(with_metaclass(Singleton, object)):
         '''
         Get a reset color (terminal escape sequence).
         '''
-        if not sys.stdout.isatty():
+        if not self._should_use_color():
             return ''
         else:
             return Color.RESET


### PR DESCRIPTION
By default, if output is a TTY, dotbot will colorize the output. This
patch adds the option to pass `--no-color` to dotbot to have it suppress
this colorization.

My terminal colors are such that the ones used by dotbot aren't useful and in some cases are hard to read (see attached image).

I tried to add tests, but unfortunately all test output is piped so no colors would appear anyway.

I tried running tests through `script` which tricks python into thinking is is a TTY, but ran into problems  somewhere between vagrant and the test setup that I couldn't figure out.

<img width="284" alt="no-color-before-and-after" src="https://user-images.githubusercontent.com/16705/46576596-758e6d80-c982-11e8-86a6-e46985aff44c.png">
