### PR TITLE
Support defining default conditional option for links

### DIFF
--- a/dotbot/plugins/link.py
+++ b/dotbot/plugins/link.py
@@ -30,12 +30,10 @@ class Link(dotbot.Plugin):
             relink = defaults.get('relink', False)
             create = defaults.get('create', False)
             use_glob = defaults.get('glob', False)
+            test = defaults.get('if', None)
             if isinstance(source, dict):
                 # extended config
-                test = source.get('if')
-                if test is not None and not self._test_success(test):
-                    self._log.lowinfo('Skipping %s' % destination)
-                    continue
+                test = source.get('if', test)
                 relative = source.get('relative', relative)
                 force = source.get('force', force)
                 relink = source.get('relink', relink)
@@ -44,6 +42,9 @@ class Link(dotbot.Plugin):
                 path = self._default_source(destination, source.get('path'))
             else:
                 path = self._default_source(destination, source)
+            if test is not None and not self._test_success(test):
+                self._log.lowinfo('Skipping %s' % destination)
+                continue
             path = os.path.expandvars(os.path.expanduser(path))
             if use_glob:
                 self._log.debug("Globbing with path: " + str(path))


### PR DESCRIPTION
Small commit to make the conditional links added in #169 more consistent with every other option by inheriting an `if` defined in the `defaults` tasks.

example:
```
defaults:
  link:
    if: '[ "$(uname)" "==" "Darwin" ]'

link:
  ~/.Brewfile: Brewfile
  ~/.chunkwmrc: chunkwm/chunkwmrc.sh

defaults:
  link:
    if: '[ "$(expr substr $(uname -s) 1 5)" "==" "Linux" ]'

link:
  ~/.xinitrc: xinitrc
  ~/.xprofile: xprofile
```

I like that it is more consistent, but I'm not a fan of how wasteful it is to be calling the same conditional for each link command. I'd prefer a conditional task, but I'm not sure of how that'd be optimally designed.

I also tried adding tests, but I couldn't get vagrant running on my system, apologies