### PR TITLE
don't set executable arg to subprocess.call on Windows

### DIFF
--- a/dotbot/plugins/link.py
+++ b/dotbot/plugins/link.py
@@ -24,6 +24,8 @@ class Link(dotbot.Plugin):
         success = True
         defaults = self._context.defaults().get('link', {})
         for destination, source in links.items():
+            destination = os.path.normpath(destination)
+            source = os.path.normpath(source)
             destination = os.path.expandvars(destination)
             relative = defaults.get('relative', False)
             force = defaults.get('force', False)

--- a/dotbot/plugins/link.py
+++ b/dotbot/plugins/link.py
@@ -24,9 +24,9 @@ class Link(dotbot.Plugin):
         success = True
         defaults = self._context.defaults().get('link', {})
         for destination, source in links.items():
+            destination = os.path.expandvars(destination)
             destination = os.path.normpath(destination)
             source = os.path.normpath(source)
-            destination = os.path.expandvars(destination)
             relative = defaults.get('relative', False)
             force = defaults.get('force', False)
             relink = defaults.get('relink', False)

--- a/dotbot/plugins/link.py
+++ b/dotbot/plugins/link.py
@@ -25,8 +25,10 @@ class Link(dotbot.Plugin):
         defaults = self._context.defaults().get('link', {})
         for destination, source in links.items():
             destination = os.path.expandvars(destination)
-            destination = os.path.normpath(destination)
-            source = os.path.normpath(source)
+            if destination:
+                destination = os.path.normpath(destination)
+            if source:
+                source = os.path.normpath(source)
             relative = defaults.get('relative', False)
             force = defaults.get('force', False)
             relink = defaults.get('relink', False)

--- a/dotbot/plugins/shell.py
+++ b/dotbot/plugins/shell.py
@@ -55,6 +55,8 @@ class Shell(dotbot.Plugin):
                 else:
                     self._log.lowinfo('%s [%s]' % (msg, cmd))
                 executable = os.environ.get('SHELL')
+                if os.name == 'nt':
+                    executable = None
                 ret = subprocess.call(cmd, shell=True, stdin=stdin, stdout=stdout,
                     stderr=stderr, cwd=self._context.base_directory(),
                     executable=executable)


### PR DESCRIPTION
as https://bugs.python.org/issue2304 said,

executable given

`C:\\Program Files\\Git\\usr\\bin\\bash.exe`

this PR is a workaround for windows.

Possiable relate to #170 

if you have to expand command like '~', you
should straight tell to use git bash like
`"bash -c 'your command'"` ,make sure that bash
is in your  `PATH`.