### PR TITLE
Create missing target files/folders from source

### DIFF
--- a/dotbot/plugins/link.py
+++ b/dotbot/plugins/link.py
@@ -255,10 +255,10 @@ class Link(dotbot.Plugin):
         # again, we use absolute_source to check for existence
         elif not self._exists(absolute_source):
             if self._is_link(link_name):
-                self._log.warning('Nonexistent target %s -> %s' %
+                self._log.warning('Nonexistent source %s -> %s' %
                     (link_name, source))
             else:
-                self._log.warning('Nonexistent target for %s : %s' %
+                self._log.warning('Nonexistent source for %s : %s' %
                     (link_name, source))
         else:
             self._log.lowinfo('Link exists %s -> %s' % (link_name, source))

--- a/dotbot/plugins/link.py
+++ b/dotbot/plugins/link.py
@@ -243,7 +243,7 @@ class Link(dotbot.Plugin):
             except OSError:
                 self._log.warning('Linking failed %s -> %s' % (link_name, source))
             else:
-                self._log.lowinfo('Creating link %s -> %s' % (link_name, source))
+                self._log.info('Creating link %s -> %s' % (link_name, source))
                 success = True
         elif self._exists(link_name) and not self._is_link(link_name):
             self._log.warning(

--- a/test/tests/link-creates-when-nonexistent.bash
+++ b/test/tests/link-creates-when-nonexistent.bash
@@ -1,4 +1,4 @@
-test_description='force leaves file when target nonexistent'
+test_description='link creates target and links file when target nonexistent'
 . '../test-lib.bash'
 
 test_expect_success 'setup' '
@@ -6,7 +6,7 @@ mkdir ~/dir &&
 touch ~/file
 '
 
-test_expect_failure 'run' '
+test_expect_success 'run' '
 run_dotbot <<EOF
 - link:
     ~/dir:
@@ -19,6 +19,8 @@ EOF
 '
 
 test_expect_success 'test' '
-test -d ~/dir &&
-test -f ~/file
+test -L ~/dir &&
+test -L ~/file &&
+test -d ${DOTFILES}/dir &&
+test -f ${DOTFILES}/file
 '


### PR DESCRIPTION
If the target in the dotbot-repo doesn't exist, copy from the original. The links are then created afterwards.

This implements the behaviour described in #180.