### PR TITLE
Fix - Shell scripts to check python binary in windows

### DIFF
--- a/bin/dotbot
+++ b/bin/dotbot
@@ -7,9 +7,9 @@
 # is useful because we don't know the name of the python binary.
 
 ''':' # begin python string; this line is interpreted by the shell as `:`
-which python3 >/dev/null 2>&1 && exec python3 "$0" "$@"
 which python  >/dev/null 2>&1 && exec python  "$0" "$@"
 which python2 >/dev/null 2>&1 && exec python2 "$0" "$@"
+which python3 >/dev/null 2>&1 && exec python3 "$0" "$@"
 >&2 echo "error: cannot find python"
 exit 1
 '''


### PR DESCRIPTION
This closes #187 which I am facing repeatedly due to accident installation of python via the Windows App store. Windows App store always adds it if I sign in with Windows account and no rules over there to delete it permanently. Thus making PR over here.