### PR TITLE
Support named, conditional tasks

### DIFF
--- a/dotbot/dispatcher.py
+++ b/dotbot/dispatcher.py
@@ -2,6 +2,7 @@ import os
 from .plugin import Plugin
 from .messenger import Messenger
 from .context import Context
+from .util import test_success
 
 class Dispatcher(object):
     def __init__(self, base_directory, only=None, skip=None):
@@ -21,7 +22,13 @@ class Dispatcher(object):
     def dispatch(self, tasks):
         success = True
         for task in tasks:
+            test = task.get('if', None)
+            if test is not None and not test_success(test, cwd=self._context.base_directory(), log=self._log):
+                self._log.lowinfo('Skipping task')
+                continue
             for action in task:
+                if action == 'if':
+                    continue
                 if self._only is not None and action not in self._only \
                         or self._skip is not None and action in self._skip:
                     self._log.info('Skipping action %s' % action)

--- a/dotbot/plugins/link.py
+++ b/dotbot/plugins/link.py
@@ -47,7 +47,7 @@ class Link(dotbot.Plugin):
                 path = self._default_source(destination, source.get('path'))
             else:
                 path = self._default_source(destination, source)
-            if test is not None and not self._test_success(test):
+            if test is not None and not dotbot.util.test_success(test, cwd=self._context.base_directory(), log=self._log):
                 self._log.lowinfo('Skipping %s' % destination)
                 continue
             path = os.path.expandvars(os.path.expanduser(path))
@@ -104,12 +104,6 @@ class Link(dotbot.Plugin):
         else:
             self._log.error('Some links were not successfully set up')
         return success
-
-    def _test_success(self, command):
-        ret = dotbot.util.shell_command(command, cwd=self._context.base_directory())
-        if ret != 0:
-            self._log.debug('Test \'%s\' returned false' % command)
-        return ret == 0
 
     def _default_source(self, destination, source):
         if source is None:

--- a/dotbot/util/__init__.py
+++ b/dotbot/util/__init__.py
@@ -1,1 +1,1 @@
-from .common import shell_command
+from .common import shell_command, test_success

--- a/dotbot/util/common.py
+++ b/dotbot/util/common.py
@@ -32,3 +32,9 @@ def shell_command(command, cwd=None, enable_stdin=False, enable_stdout=False, en
             stderr=stderr,
             cwd=cwd
         )
+
+def test_success(command, cwd=None, log=None):
+    ret = shell_command(command, cwd=cwd)
+    if ret != 0 and log != None:
+        log.debug('Test \'%s\' returned false' % command)
+    return ret == 0


### PR DESCRIPTION
Just like on a link action, the value is executed in the shell. If it has a non-zero exit code (indicating failure), the whole task is skipped.

This allows tasks to group actions that only apply in certain conditions (e.g. on certain OSes or in certain configurations), and allows all actions (not just link) to be conditional.

Resolves #225.