### PR TITLE
Added support for python -m dotbot

### DIFF
--- a/dotbot/__main__.py
+++ b/dotbot/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This tiny PR adds support for invoking dotbot using the following.

```bash
python -m dotbot
```

This is particularly useful when Python is located on your PATH, but the scripts directory of python is not.