### PR TITLE
Add `--force-color` option

### DIFF
--- a/dotbot/cli.py
+++ b/dotbot/cli.py
@@ -1,4 +1,5 @@
 import os, glob
+import sys
 
 from argparse import ArgumentParser
 from .config import ConfigReader, ReadingError
@@ -32,6 +33,8 @@ def add_options(parser):
             help='only run specified directives', metavar='DIRECTIVE')
     parser.add_argument('--except', nargs='+', dest='skip',
             help='skip specified directives', metavar='DIRECTIVE')
+    parser.add_argument('--force-color', dest='force_color', action='store_true',
+        help='force color output')
     parser.add_argument('--no-color', dest='no_color', action='store_true',
         help='disable color output')
     parser.add_argument('--version', action='store_true',
@@ -56,8 +59,17 @@ def main():
             log.set_level(Level.INFO)
         if options.verbose:
             log.set_level(Level.DEBUG)
-        if options.no_color:
+
+        if options.force_color and options.no_color:
+            log.error("`--force-color` and `--no-color` cannot both be provided")
+            exit(1)
+        elif options.force_color:
+            log.use_color(True)
+        elif options.no_color:
             log.use_color(False)
+        else:
+            log.use_color(sys.stdout.isatty())
+
         plugin_directories = list(options.plugin_dirs)
         if not options.disable_built_in_plugins:
             from .plugins import Clean, Create, Link, Shell

--- a/dotbot/messenger/messenger.py
+++ b/dotbot/messenger/messenger.py
@@ -1,4 +1,3 @@
-import sys
 from ..util.singleton import Singleton
 from ..util.compat import with_metaclass
 from .color import Color
@@ -34,14 +33,11 @@ class Messenger(with_metaclass(Singleton, object)):
     def error(self, message):
         self.log(Level.ERROR, message)
 
-    def _should_use_color(self):
-        return self._use_color and sys.stdout.isatty()
-
     def _color(self, level):
         '''
         Get a color (terminal escape sequence) according to a level.
         '''
-        if not self._should_use_color():
+        if not self._use_color:
             return ''
         elif level < Level.DEBUG:
             return ''
@@ -60,7 +56,7 @@ class Messenger(with_metaclass(Singleton, object)):
         '''
         Get a reset color (terminal escape sequence).
         '''
-        if not self._should_use_color():
+        if not self._use_color:
             return ''
         else:
             return Color.RESET


### PR DESCRIPTION
This forces Dotbot to produce colored output, regardless of whether it is outputting to a TTY.

This is useful to support use cases such as piping colored Dotbot output into another program for formatting (e.g. I want to indent the output as part of a larger installation script); this was not previously easy to do as this would cause the output to lose its colored formatting.

This option cannot be provided at the same time as the existing `--no-color` option, as there's no logical interpretation of what effect providing both of these should have.

As part of this change I've refactored some existing code determining whether output should be colored to where options are parsed, as this made this change simpler and I think it makes sense for all this logic to be performed in the same place.

This change results in behaviour like this:

![2020-08-22_23:54:42](https://user-images.githubusercontent.com/7476523/90967409-b8a24d00-e4d6-11ea-97ed-c9bc4906f627.png)
