### PR TITLE
Allow linking a directory in windows based bash environments

### DIFF
--- a/dotbot/plugins/link.py
+++ b/dotbot/plugins/link.py
@@ -214,7 +214,7 @@ class Link(dotbot.Plugin):
         # destination directory
         elif not self._exists(link_name) and (ignore_missing or self._exists(absolute_source)):
             try:
-                os.symlink(source, destination)
+                os.symlink(source, destination, os.path.isdir(source))
             except OSError:
                 self._log.warning('Linking failed %s -> %s' % (link_name, source))
             else:


### PR DESCRIPTION
To create a directory symlink in windows 10 git bash, the target_is_directory must be set to true