### PR TITLE
link.py: globbing keep leading '.'

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,13 @@ Implicit sources:
       relink: true
 ```
 
+#### Limitations of `glob`
+
+Dotbot uses [glob()](https://docs.python.org/3.9/library/glob.html) to resolve
+glob paths. However, due to its design, using a glob path such as `config/*` for
+example, will not match items that being with `.`. To specifically capture
+items that being with `.`, you will need to use a path like this: `config/.*`.
+
 ### Create
 
 Create commands specify empty directories to be created.  This can be useful

--- a/dotbot/plugins/link.py
+++ b/dotbot/plugins/link.py
@@ -76,6 +76,8 @@ class Link(dotbot.Plugin):
                 else:
                     self._log.lowinfo("Globs from '" + path + "': " + str(glob_results))
                     glob_base = path[:glob_star_loc]
+                    if glob_base.endswith('/.'):
+                        glob_base = path[:glob_star_loc - 1]
                     for glob_full_item in glob_results:
                         glob_item = glob_full_item[len(glob_base):]
                         glob_link_destination = os.path.join(destination, glob_item)

--- a/test/tests/link-glob-multi-star.bash
+++ b/test/tests/link-glob-multi-star.bash
@@ -1,4 +1,4 @@
-test_description='link glob'
+test_description='link glob multi star'
 . '../test-lib.bash'
 
 test_expect_success 'setup' '

--- a/test/tests/link-glob.bash
+++ b/test/tests/link-glob.bash
@@ -45,3 +45,27 @@ grep "apple" ~/bin/a &&
 grep "banana" ~/bin/b &&
 grep "cherry" ~/bin/c
 '
+
+test_expect_success 'setup 3' '
+rm -rf ~/bin &&
+echo "dot_apple" > ${DOTFILES}/bin/.a &&
+echo "dot_banana" > ${DOTFILES}/bin/.b &&
+echo "dot_cherry" > ${DOTFILES}/bin/.c
+'
+
+test_expect_success 'run 3' '
+run_dotbot -v <<EOF
+- defaults:
+    link:
+      glob: true
+      create: true
+- link:
+    ~/bin/: bin/.*
+EOF
+'
+
+test_expect_success 'test 3' '
+grep "dot_apple" ~/bin/.a &&
+grep "dot_banana" ~/bin/.b &&
+grep "dot_cherry" ~/bin/.c
+'


### PR DESCRIPTION
- Updated plugins/link.py so that globbing will not strip leading '.' when
    creating link names.
- Corrected test collection output in test/link-glob-multi-start

Fixes #244