### PR TITLE
Add exclude parameter for link globbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ mapped to extended configuration dictionaries.
 | `glob` | Treat a `*` character as a wildcard, and perform link operations on all of those matches (default: false) |
 | `if` | Execute this in your `$SHELL` and only link if it is successful. |
 | `ignore-missing` | Do not fail if the source is missing and create the link anyway (default: false) |
+| `exclude` | Array of paths to remove from glob matches. Uses same syntax as `path`. Ignored if `glob` is `false`. (default: empty, keep all matches) |
 
 #### Example
 
@@ -218,6 +219,12 @@ Explicit sources:
       glob: true
       path: config/*
       relink: true
+      exclude: [ config/Code ]
+    ~/.config/Code/User/:
+      create: true
+      glob: true
+      path: config/Code/User/*
+      relink: true
 ```
 
 Implicit sources:
@@ -233,6 +240,12 @@ Implicit sources:
     ~/.config/:
       glob: true
       path: config/*
+      relink: true
+      exclude: [ config/Code ]
+    ~/.config/Code/User/:
+      create: true
+      glob: true
+      path: config/Code/User/*
       relink: true
 ```
 

--- a/test/tests/link-glob-exclude.bash
+++ b/test/tests/link-glob-exclude.bash
@@ -1,0 +1,123 @@
+test_description='link glob exclude'
+. '../test-lib.bash'
+
+test_expect_success 'setup 1' '
+mkdir -p ${DOTFILES}/config/{foo,bar,baz} &&
+echo "apple" > ${DOTFILES}/config/foo/a &&
+echo "banana" > ${DOTFILES}/config/bar/b &&
+echo "cherry" > ${DOTFILES}/config/bar/c &&
+echo "donut" > ${DOTFILES}/config/baz/d
+'
+
+test_expect_success 'run 1' '
+run_dotbot -v <<EOF
+- defaults:
+    link:
+      glob: true
+      create: true
+- link:
+    ~/.config/:
+      path: config/*
+      exclude: [config/baz]
+EOF
+'
+
+test_expect_success 'test 1' '
+! readlink ~/.config/ &&
+readlink ~/.config/foo &&
+! readlink ~/.config/baz &&
+grep "apple" ~/.config/foo/a &&
+grep "banana" ~/.config/bar/b &&
+grep "cherry" ~/.config/bar/c
+'
+
+test_expect_success 'setup 2' '
+rm -rf ~/.config &&
+mkdir ${DOTFILES}/config/baz/buzz &&
+echo "egg" > ${DOTFILES}/config/baz/buzz/e
+'
+
+test_expect_success 'run 2' '
+run_dotbot -v <<EOF
+- defaults:
+    link:
+      glob: true
+      create: true
+- link:
+    ~/.config/:
+      path: config/*/*
+      exclude: [config/baz/*]
+EOF
+'
+
+test_expect_success 'test 2' '
+! readlink ~/.config/ &&
+! readlink ~/.config/foo &&
+[ ! -d ~/.config/baz ] &&
+readlink ~/.config/foo/a &&
+grep "apple" ~/.config/foo/a &&
+grep "banana" ~/.config/bar/b &&
+grep "cherry" ~/.config/bar/c
+'
+
+test_expect_success 'setup 3' '
+rm -rf ~/.config &&
+mkdir ${DOTFILES}/config/baz/bizz &&
+echo "grape" > ${DOTFILES}/config/baz/bizz/g
+'
+
+test_expect_success 'run 3' '
+run_dotbot -v <<EOF
+- defaults:
+    link:
+      glob: true
+      create: true
+- link:
+    ~/.config/:
+      path: config/*/*
+      exclude: [config/baz/buzz]
+EOF
+'
+
+test_expect_success 'test 3' '
+! readlink ~/.config/ &&
+! readlink ~/.config/foo &&
+readlink ~/.config/foo/a &&
+! readlink ~/.config/baz/buzz &&
+readlink ~/.config/baz/bizz &&
+grep "apple" ~/.config/foo/a &&
+grep "banana" ~/.config/bar/b &&
+grep "cherry" ~/.config/bar/c &&
+grep "donut" ~/.config/baz/d &&
+grep "grape" ~/.config/baz/bizz/g
+'
+
+test_expect_success 'setup 4' '
+rm -rf ~/.config &&
+mkdir ${DOTFILES}/config/fiz &&
+echo "fig" > ${DOTFILES}/config/fiz/f
+'
+
+test_expect_success 'run 4' '
+run_dotbot -v <<EOF
+- defaults:
+    link:
+      glob: true
+      create: true
+- link:
+    ~/.config/:
+      path: config/*/*
+      exclude: [config/baz/*, config/fiz/*]
+EOF
+'
+
+test_expect_success 'test 4' '
+! readlink ~/.config/ &&
+! readlink ~/.config/foo &&
+[ ! -d ~/.config/baz ] &&
+[ ! -d ~/.config/fiz ] &&
+readlink ~/.config/foo/a &&
+grep "apple" ~/.config/foo/a &&
+grep "banana" ~/.config/bar/b &&
+grep "cherry" ~/.config/bar/c
+'


### PR DESCRIPTION
- Added `exclude` parameter to _link_. Now, an array of glob patterns
    can be given that will be used to remove items from a glob match.
    This parameter will only have an effect when `glob` is `true`.
- Updated README to add description for `exclude` and add in examples.

Resolves #247