### PR TITLE
Make parsed cli options available to plugins

### DIFF
--- a/dotbot/cli.py
+++ b/dotbot/cli.py
@@ -97,7 +97,7 @@ def main():
             # default to directory of config file
             base_directory = os.path.dirname(os.path.abspath(options.config_file))
         os.chdir(base_directory)
-        dispatcher = Dispatcher(base_directory, only=options.only, skip=options.skip)
+        dispatcher = Dispatcher(base_directory, only=options.only, skip=options.skip, options=options)
         success = dispatcher.dispatch(tasks)
         if success:
             log.info('\n==> All tasks executed successfully')

--- a/dotbot/context.py
+++ b/dotbot/context.py
@@ -6,9 +6,10 @@ class Context(object):
     Contextual data and information for plugins.
     '''
 
-    def __init__(self, base_directory):
+    def __init__(self, base_directory, options):
         self._base_directory = base_directory
         self._defaults = {}
+        self._options = options
         pass
 
     def set_base_directory(self, base_directory):
@@ -25,3 +26,8 @@ class Context(object):
 
     def defaults(self):
         return copy.deepcopy(self._defaults)
+
+    def options(self):
+        if self._options is not None:
+            return copy.deepcopy(self._options)
+        return None

--- a/dotbot/context.py
+++ b/dotbot/context.py
@@ -1,12 +1,13 @@
 import copy
 import os
+from argparse import Namespace
 
 class Context(object):
     '''
     Contextual data and information for plugins.
     '''
 
-    def __init__(self, base_directory, options):
+    def __init__(self, base_directory, options=Namespace()):
         self._base_directory = base_directory
         self._defaults = {}
         self._options = options
@@ -28,6 +29,4 @@ class Context(object):
         return copy.deepcopy(self._defaults)
 
     def options(self):
-        if self._options is not None:
-            return copy.deepcopy(self._options)
-        return None
+        return copy.deepcopy(self._options)

--- a/dotbot/dispatcher.py
+++ b/dotbot/dispatcher.py
@@ -4,19 +4,23 @@ from .messenger import Messenger
 from .context import Context
 
 class Dispatcher(object):
-    def __init__(self, base_directory, only=None, skip=None):
+    def __init__(self, base_directory, only=None, skip=None, options=None):
         self._log = Messenger()
-        self._setup_context(base_directory)
+        self._setup_context(base_directory, options)
         self._load_plugins()
-        self._only = only
-        self._skip = skip
+        if options is not None:
+            self._only = options.only
+            self._skip = options.skip
+        else:
+            self._only = only
+            self._skip = skip
 
-    def _setup_context(self, base_directory):
+    def _setup_context(self, base_directory, options):
         path = os.path.abspath(
             os.path.expanduser(base_directory))
         if not os.path.exists(path):
             raise DispatchError('Nonexistent base directory')
-        self._context = Context(path)
+        self._context = Context(path, options)
 
     def dispatch(self, tasks):
         success = True

--- a/dotbot/dispatcher.py
+++ b/dotbot/dispatcher.py
@@ -1,19 +1,16 @@
 import os
+from argparse import Namespace
 from .plugin import Plugin
 from .messenger import Messenger
 from .context import Context
 
 class Dispatcher(object):
-    def __init__(self, base_directory, only=None, skip=None, options=None):
+    def __init__(self, base_directory, only=None, skip=None, options=Namespace()):
         self._log = Messenger()
         self._setup_context(base_directory, options)
         self._load_plugins()
-        if options is not None:
-            self._only = options.only
-            self._skip = options.skip
-        else:
-            self._only = only
-            self._skip = skip
+        self._only = options.only or only
+        self._skip = options.skip or skip
 
     def _setup_context(self, base_directory, options):
         path = os.path.abspath(

--- a/test/tests/plugin.bash
+++ b/test/tests/plugin.bash
@@ -40,9 +40,6 @@ class Test(dotbot.Plugin):
     def handle(self, directive, data):
         self._log.debug("Attempting to get options from Context")
         options = self._context.options()
-        if options is None:
-            self._log.debug("Context.options is None, expected not None")
-            return False
         if len(options.plugins) != 1:
             self._log.debug("Context.options.plugins length is %i, expected 1" % len(options.plugins))
             return False

--- a/test/tests/plugin.bash
+++ b/test/tests/plugin.bash
@@ -1,7 +1,7 @@
 test_description='plugin loading works'
 . '../test-lib.bash'
 
-test_expect_success 'setup' '
+test_expect_success 'setup 1' '
 cat > ${DOTFILES}/test.py <<EOF
 import dotbot
 import os.path
@@ -17,12 +17,51 @@ class Test(dotbot.Plugin):
 EOF
 '
 
-test_expect_success 'run' '
+test_expect_success 'run 1' '
 run_dotbot --plugin ${DOTFILES}/test.py <<EOF
 - test: ~
 EOF
 '
 
-test_expect_success 'test' '
+test_expect_success 'test 1' '
+grep "it works" ~/flag
+'
+
+test_expect_success 'setup 2' '
+rm ${DOTFILES}/test.py;
+cat > ${DOTFILES}/test.py <<EOF
+import dotbot
+import os.path
+
+class Test(dotbot.Plugin):
+    def can_handle(self, directive):
+        return directive == "test"
+
+    def handle(self, directive, data):
+        self._log.debug("Attempting to get options from Context")
+        options = self._context.options()
+        if options is None:
+            self._log.debug("Context.options is None, expected not None")
+            return False
+        if len(options.plugins) != 1:
+            self._log.debug("Context.options.plugins length is %i, expected 1" % len(options.plugins))
+            return False
+        if not options.plugins[0].endswith("test.py"):
+            self._log.debug("Context.options.plugins[0] is %s, expected end with tesp.py" % options.plugins[0])
+            return False
+
+        with open(os.path.expanduser("~/flag"), "w") as f:
+            f.write("it works")
+        return True
+EOF
+'
+
+test_expect_success 'run 2' '
+run_dotbot --plugin ${DOTFILES}/test.py <<EOF
+- test: ~
+EOF
+'
+
+test_expect_success 'test 2' '
 grep "it works" ~/flag
 '


### PR DESCRIPTION
- `Context` now provides a copy of the parsed cli options so that they
    can be used by plugins.
- Modified `Dispatcher` to pass parsed cli options to `Context`

Resolves #249

I'd consider myself an experienced junior developer with python. I'm questioning if I used optional arguments correctly. Also, I wasn't sure if optional arguments were to be listed alphabetically. I tried to do what I thought was best to not break backwards compatibility. 