### PR TITLE
Add cli option force shell show stderr/stdout

### DIFF
--- a/dotbot/cli.py
+++ b/dotbot/cli.py
@@ -1,7 +1,7 @@
 import os, glob
 import sys
 
-from argparse import ArgumentParser
+from argparse import ArgumentParser, RawTextHelpFormatter
 from .config import ConfigReader, ReadingError
 from .dispatcher import Dispatcher, DispatchError
 from .messenger import Messenger
@@ -16,8 +16,10 @@ def add_options(parser):
         help='suppress almost all output')
     parser.add_argument('-q', '--quiet', action='store_true',
         help='suppress most output')
-    parser.add_argument('-v', '--verbose', action='store_true',
-        help='enable verbose output')
+    parser.add_argument('-v', '--verbose', action='count', default=0,
+        help='enable verbose output\n'
+             '-v: typical verbose\n'
+             '-vv: also, set shell commands stderr/stdout to true')
     parser.add_argument('-d', '--base-directory',
         help='execute commands from within BASEDIR',
         metavar='BASEDIR')
@@ -47,7 +49,7 @@ def read_config(config_file):
 def main():
     log = Messenger()
     try:
-        parser = ArgumentParser()
+        parser = ArgumentParser(formatter_class=RawTextHelpFormatter)
         add_options(parser)
         options = parser.parse_args()
         if options.version:
@@ -57,7 +59,7 @@ def main():
             log.set_level(Level.WARNING)
         if options.quiet:
             log.set_level(Level.INFO)
-        if options.verbose:
+        if options.verbose > 0:
             log.set_level(Level.DEBUG)
 
         if options.force_color and options.no_color:

--- a/dotbot/cli.py
+++ b/dotbot/cli.py
@@ -97,7 +97,7 @@ def main():
             # default to directory of config file
             base_directory = os.path.dirname(os.path.abspath(options.config_file))
         os.chdir(base_directory)
-        dispatcher = Dispatcher(base_directory, only=options.only, skip=options.skip)
+        dispatcher = Dispatcher(base_directory, only=options.only, skip=options.skip, options=options)
         success = dispatcher.dispatch(tasks)
         if success:
             log.info('\n==> All tasks executed successfully')

--- a/dotbot/context.py
+++ b/dotbot/context.py
@@ -6,9 +6,10 @@ class Context(object):
     Contextual data and information for plugins.
     '''
 
-    def __init__(self, base_directory):
+    def __init__(self, base_directory, options):
         self._base_directory = base_directory
         self._defaults = {}
+        self._options = options
         pass
 
     def set_base_directory(self, base_directory):
@@ -25,3 +26,8 @@ class Context(object):
 
     def defaults(self):
         return copy.deepcopy(self._defaults)
+
+    def options(self):
+        if self._options is not None:
+            return copy.deepcopy(self._options)
+        return None

--- a/dotbot/context.py
+++ b/dotbot/context.py
@@ -1,12 +1,13 @@
 import copy
 import os
+from argparse import Namespace
 
 class Context(object):
     '''
     Contextual data and information for plugins.
     '''
 
-    def __init__(self, base_directory, options):
+    def __init__(self, base_directory, options=Namespace()):
         self._base_directory = base_directory
         self._defaults = {}
         self._options = options
@@ -28,6 +29,4 @@ class Context(object):
         return copy.deepcopy(self._defaults)
 
     def options(self):
-        if self._options is not None:
-            return copy.deepcopy(self._options)
-        return None
+        return copy.deepcopy(self._options)

--- a/dotbot/dispatcher.py
+++ b/dotbot/dispatcher.py
@@ -4,19 +4,23 @@ from .messenger import Messenger
 from .context import Context
 
 class Dispatcher(object):
-    def __init__(self, base_directory, only=None, skip=None):
+    def __init__(self, base_directory, only=None, skip=None, options=None):
         self._log = Messenger()
-        self._setup_context(base_directory)
+        self._setup_context(base_directory, options)
         self._load_plugins()
-        self._only = only
-        self._skip = skip
+        if options is not None:
+            self._only = options.only
+            self._skip = options.skip
+        else:
+            self._only = only
+            self._skip = skip
 
-    def _setup_context(self, base_directory):
+    def _setup_context(self, base_directory, options):
         path = os.path.abspath(
             os.path.expanduser(base_directory))
         if not os.path.exists(path):
             raise DispatchError('Nonexistent base directory')
-        self._context = Context(path)
+        self._context = Context(path, options)
 
     def dispatch(self, tasks):
         success = True

--- a/dotbot/dispatcher.py
+++ b/dotbot/dispatcher.py
@@ -1,19 +1,16 @@
 import os
+from argparse import Namespace
 from .plugin import Plugin
 from .messenger import Messenger
 from .context import Context
 
 class Dispatcher(object):
-    def __init__(self, base_directory, only=None, skip=None, options=None):
+    def __init__(self, base_directory, only=None, skip=None, options=Namespace()):
         self._log = Messenger()
         self._setup_context(base_directory, options)
         self._load_plugins()
-        if options is not None:
-            self._only = options.only
-            self._skip = options.skip
-        else:
-            self._only = only
-            self._skip = skip
+        self._only = options.only or only
+        self._skip = options.skip or skip
 
     def _setup_context(self, base_directory, options):
         path = os.path.abspath(

--- a/test/tests/plugin.bash
+++ b/test/tests/plugin.bash
@@ -40,9 +40,6 @@ class Test(dotbot.Plugin):
     def handle(self, directive, data):
         self._log.debug("Attempting to get options from Context")
         options = self._context.options()
-        if options is None:
-            self._log.debug("Context.options is None, expected not None")
-            return False
         if len(options.plugins) != 1:
             self._log.debug("Context.options.plugins length is %i, expected 1" % len(options.plugins))
             return False

--- a/test/tests/plugin.bash
+++ b/test/tests/plugin.bash
@@ -1,7 +1,7 @@
 test_description='plugin loading works'
 . '../test-lib.bash'
 
-test_expect_success 'setup' '
+test_expect_success 'setup 1' '
 cat > ${DOTFILES}/test.py <<EOF
 import dotbot
 import os.path
@@ -17,12 +17,51 @@ class Test(dotbot.Plugin):
 EOF
 '
 
-test_expect_success 'run' '
+test_expect_success 'run 1' '
 run_dotbot --plugin ${DOTFILES}/test.py <<EOF
 - test: ~
 EOF
 '
 
-test_expect_success 'test' '
+test_expect_success 'test 1' '
+grep "it works" ~/flag
+'
+
+test_expect_success 'setup 2' '
+rm ${DOTFILES}/test.py;
+cat > ${DOTFILES}/test.py <<EOF
+import dotbot
+import os.path
+
+class Test(dotbot.Plugin):
+    def can_handle(self, directive):
+        return directive == "test"
+
+    def handle(self, directive, data):
+        self._log.debug("Attempting to get options from Context")
+        options = self._context.options()
+        if options is None:
+            self._log.debug("Context.options is None, expected not None")
+            return False
+        if len(options.plugins) != 1:
+            self._log.debug("Context.options.plugins length is %i, expected 1" % len(options.plugins))
+            return False
+        if not options.plugins[0].endswith("test.py"):
+            self._log.debug("Context.options.plugins[0] is %s, expected end with tesp.py" % options.plugins[0])
+            return False
+
+        with open(os.path.expanduser("~/flag"), "w") as f:
+            f.write("it works")
+        return True
+EOF
+'
+
+test_expect_success 'run 2' '
+run_dotbot --plugin ${DOTFILES}/test.py <<EOF
+- test: ~
+EOF
+'
+
+test_expect_success 'test 2' '
 grep "it works" ~/flag
 '

--- a/test/tests/shell-cli-override-config.bash
+++ b/test/tests/shell-cli-override-config.bash
@@ -1,0 +1,79 @@
+test_description='cli options can override config file'
+. '../test-lib.bash'
+
+test_expect_success 'run 1' '
+(run_dotbot -vv | (grep "^apple")) <<EOF
+- shell:
+  -
+    command: echo apple
+EOF
+'
+
+test_expect_success 'run 2' '
+(run_dotbot -vv | (grep "^apple")) <<EOF
+- shell:
+  -
+    command: echo apple
+    stdout: false
+EOF
+'
+
+test_expect_success 'run 3' '
+(run_dotbot -vv | (grep "^apple")) <<EOF
+- defaults:
+    shell:
+      stdout: false
+- shell:
+  - command: echo apple
+EOF
+'
+
+# Control to make sure stderr redirection is working as expected
+test_expect_failure 'run 4' '
+(run_dotbot -vv | (grep "^apple")) <<EOF
+- shell:
+  - command: echo apple >&2
+EOF
+'
+
+test_expect_success 'run 5' '
+(run_dotbot -vv 2>&1 | (grep "^apple")) <<EOF
+- shell:
+  - command: echo apple >&2
+EOF
+'
+
+test_expect_success 'run 6' '
+(run_dotbot -vv 2>&1 | (grep "^apple")) <<EOF
+- shell:
+  -
+    command: echo apple >&2
+    stdout: false
+EOF
+'
+
+test_expect_success 'run 7' '
+(run_dotbot -vv 2>&1 | (grep "^apple")) <<EOF
+- defaults:
+    shell:
+      stdout: false
+- shell:
+  - command: echo apple >&2
+EOF
+'
+
+# Make sure that we must use verbose level 2
+# This preserves backwards compatability
+test_expect_failure 'run 8' '
+(run_dotbot -v | (grep "^apple")) <<EOF
+- shell:
+  - command: echo apple
+EOF
+'
+
+test_expect_failure 'run 9' '
+(run_dotbot -v | (grep "^apple")) <<EOF
+- shell:
+  - command: echo apple >&2
+EOF
+'


### PR DESCRIPTION
Passing `--verbose` flag two times will now force shell commands to show stderr/stdout output regardless of settings in config file.

Resolves #104 

**Commits d6e1e4a and earlier are requested in PR #250 **
**Commits 33a4276 and later are dependent on changes above**