### PR TITLE
Canonicalize destination path for relative-path: True

### DIFF
--- a/dotbot/plugins/link.py
+++ b/dotbot/plugins/link.py
@@ -188,6 +188,7 @@ class Link(dotbot.Plugin):
         Returns the relative path to get to the source file from the
         destination file.
         '''
+        destination = os.path.realpath(destination)
         destination_dir = os.path.dirname(destination)
         return os.path.relpath(source, destination_dir)
 


### PR DESCRIPTION
The python os.path.relpath does not touch the filesystem and can return
an invalid result when the "start" argument contains symlinks.

This fixes using dotbot when $HOME is a symlink.

Signed-off-by: Leonard Crestez <cdleonard@gmail.com>