### PR TITLE
Fixes typos in README "being" to "begin"

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,8 @@ mapped to extended configuration dictionaries.
 
 Dotbot uses [glob.glob](https://docs.python.org/3/library/glob.html#glob.glob)
 to resolve glob paths. However, due to its design, using a glob path such as
-`config/*` for example, will not match items that being with `.`. To
-specifically capture items that being with `.`, you will need to use a path
+`config/*` for example, will not match items that begin with `.`. To
+specifically capture items that begin with `.`, you will need to use a path
 like this: `config/.*`.
 
 #### Example


### PR DESCRIPTION
Tiny PR to correct 2 typos in the README - "being" should be "begin".