### PR TITLE
test: fix `pyenv` configuration in vagrant

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -2,54 +2,78 @@ Testing
 =======
 
 Dotbot testing code uses [Vagrant] to run all tests inside a virtual machine to
-have tests be completely isolated from the host machine.
+have tests be completely isolated from the host machine.  Specifically, you
+will need both:
 
-Installing the Test environnement
----------------------------------
+  - [VirtualBox]
+  - [Vagrant]
+
+Install Dotbot dependencies
+---------------------------
+
+Ensure you have updated the `dotbot` submodule dependencies, on the host machine:
+
+```bash
+git submodule sync --quiet --recursive
+git submodule update --init --recursive
+```
+Install Vagrant
+---------------
 
 ### Debian-based distributions
-
-- Install the test requirements
 
 ```bash
 sudo apt install vagrant virtualbox
 ```
 
-- Install Dotbot dependencies
-
-```bash
-git submodule update --init --recursive
-```
-
 ### macOS
 
-- Install the test requirements
-    - [VirtualBox]
-    - [Vagrant]
-
-- Install Dotbot dependencies
+You can download those directly from the above URLs, or via some MacOS package managers.
+e.g. using [HomeBrew](https://brew.sh/):
 
 ```bash
-git submodule update --init --recursive
+brew cask install virtualbox
+brew cask install vagrant
+# optional, adding menu-bar support:
+brew cask install vagrant-manager
 ```
 
 Running the Tests
 -----------------
 
-Before running the tests, you must SSH into the VM. Start it with `vagrant up`
-and SSH in with `vagrant ssh`. All following commands must be run inside the
-VM.
+Before running the tests, you must start and `ssh` into the VM:
 
-First, you must install a version of Python to test against, using `pyenv
-install -s {version}`. You can choose any version you like, e.g. `3.8.1`. It
-isn't particularly important to test against all supported versions of Python
-in the VM, because they will be tested by CI. Once you've installed a specific
-version of Python, activate it with `pyenv global {version}`.
+```bash
+vagrant up
+vagrant ssh
+```
 
-The VM mounts the Dotbot directory in `/dotbot` as read-only (you can make
-edits on your host machine). You can run the test suite by `cd /dotbot/test`
-and then running `./test`. Selected tests can be run by passing paths to the
-tests as arguments, e.g. `./test tests/create.bash tests/defaults.bash`.
+All remaining commands are run inside the VM.
+
+First, you must install a version of Python to test against, using:
+
+    pyenv install -s {version}
+
+You can choose any version you like, e.g. `3.8.1`. It isn't particularly
+important to test against all supported versions of Python in the VM, because
+they will be tested by CI. Once you've installed a specific version of Python,
+activate it with:
+
+    pyenv global {version}
+
+The VM mounts your host's Dotbot directory in `/dotbot` as read-only, allowing
+you to make edits on your host machine.  Run the entire test suite by:
+
+```bash
+cd /dotbot/test
+./test
+```
+
+Selected tests can be run by passing paths to the tests as arguments, e.g.:
+
+```bash
+./test tests/create.bash tests/defaults.bash
+```
 
 To debug tests, you can run the test driver with the `--debug` (or `-d` short
 form) flag, e.g. `./test --debug tests/link-if.bash`. This will enable printing
@@ -58,5 +82,5 @@ stdout/stderr.
 When finished with testing, it is good to shut down the virtual machine by
 running `vagrant halt`.
 
-[VirtualBox]: https://www.virtualbox.org/wiki/Downloads
+[VirtualBox]: https://www.virtualbox.org/
 [Vagrant]: https://www.vagrantup.com/

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -16,9 +16,13 @@ Vagrant.configure(2) do |config|
 
   # install pyenv
   config.vm.provision "shell", privileged: false, inline: <<-EOS
-    rm -rf ~/.pyenv
-    git clone git://github.com/yyuu/pyenv.git ~/.pyenv
-    echo 'export PATH="$HOME/.pyenv/bin:$PATH"\neval "$(pyenv init -)"' \
-      > ~/.bashrc
+    # rm -rf ~/.pyenv
+    # git clone git://github.com/yyuu/pyenv.git ~/.pyenv
+    cat <<-'PYENV' > ~/.bashrc
+			export PYENV_ROOT="$HOME/.pyenv"
+			export PATH="$PYENV_ROOT/bin:$PATH"
+			eval "$(pyenv init --path)"
+			eval "$(pyenv init -)"
+PYENV
   EOS
 end

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -16,8 +16,8 @@ Vagrant.configure(2) do |config|
 
   # install pyenv
   config.vm.provision "shell", privileged: false, inline: <<-EOS
-    # rm -rf ~/.pyenv
-    # git clone git://github.com/yyuu/pyenv.git ~/.pyenv
+    rm -rf ~/.pyenv
+    git clone git://github.com/yyuu/pyenv.git ~/.pyenv
     cat <<-'PYENV' > ~/.bashrc
 			export PYENV_ROOT="$HOME/.pyenv"
 			export PATH="$PYENV_ROOT/bin:$PATH"


### PR DESCRIPTION
- addresses change in `pyenv init -` that no longer adjusts PATH.
- also updated testing README.md for readability.

FIXES: #280