### PR TITLE
Add an "exit on failure" CLI argument

### DIFF
--- a/dotbot/cli.py
+++ b/dotbot/cli.py
@@ -42,6 +42,8 @@ def add_options(parser):
         help='disable color output')
     parser.add_argument('--version', action='store_true',
         help='show program\'s version number and exit')
+    parser.add_argument('-x', '--exit-on-failure', dest='exit_on_failure', action='store_true',
+        help='exit after first failed directive')
 
 def read_config(config_file):
     reader = ConfigReader(config_file)
@@ -107,7 +109,8 @@ def main():
             # default to directory of config file
             base_directory = os.path.dirname(os.path.abspath(options.config_file))
         os.chdir(base_directory)
-        dispatcher = Dispatcher(base_directory, only=options.only, skip=options.skip, options=options)
+        dispatcher = Dispatcher(base_directory, only=options.only, skip=options.skip,
+                                exit_on_failure=options.exit_on_failure, options=options)
         success = dispatcher.dispatch(tasks)
         if success:
             log.info('\n==> All tasks executed successfully')

--- a/test/tests/exit-on-failure.bash
+++ b/test/tests/exit-on-failure.bash
@@ -1,0 +1,19 @@
+test_description='test exit on failure'
+. '../test-lib.bash'
+
+test_expect_success 'setup' '
+echo "apple" > ${DOTFILES}/f
+'
+
+test_expect_failure 'run' '
+run_dotbot -x <<EOF
+- shell:
+    - "this_is_not_a_command"
+- link:
+    ~/f:
+EOF
+'
+
+test_expect_success 'test' '
+[[ ! -f ~/f ]]
+'

--- a/test/tests/exit-on-failure.bash
+++ b/test/tests/exit-on-failure.bash
@@ -2,18 +2,31 @@ test_description='test exit on failure'
 . '../test-lib.bash'
 
 test_expect_success 'setup' '
-echo "apple" > ${DOTFILES}/f
+echo "apple" > ${DOTFILES}/f1 &&
+echo "orange" > ${DOTFILES}/f2 &&
+echo "pineapple" > ${DOTFILES}/f3
 '
 
-test_expect_failure 'run' '
+test_expect_failure 'run_case1' '
 run_dotbot -x <<EOF
 - shell:
     - "this_is_not_a_command"
 - link:
-    ~/f:
+    ~/f1:
+EOF
+'
+
+test_expect_failure 'run_case2' '
+run_dotbot -x <<EOF
+- link:
+    ~/f2:
+- shell:
+    - "this_is_not_a_command"
+- link:
+    ~/f3:
 EOF
 '
 
 test_expect_success 'test' '
-[[ ! -f ~/f ]]
+[[ ! -f ~/f1 ]] && [[ -f ~/f2 ]] && [[ ! -f ~/f3 ]]
 '


### PR DESCRIPTION
Adds an CLI argument ( `-x`/`--exit-on-failure`) to exit dotbot on the first failed directive.

Building on the discussion in #288, this updates the `Dispatcher` with a `self._exit` member which can be set to enable this behavior. Can also be used in the proposal to change the `defaults` directive in a future PR.