### PR TITLE
Update the unauthenticated git protocol to HTTPS

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure(2) do |config|
   # install pyenv
   config.vm.provision "shell", privileged: false, inline: <<-EOS
     rm -rf ~/.pyenv
-    git clone git://github.com/yyuu/pyenv.git ~/.pyenv
+    git clone https://github.com/pyenv/pyenv.git ~/.pyenv
     cat <<-'PYENV' > ~/.bashrc
       export PYENV_ROOT="$HOME/.pyenv"
       export PATH="$PYENV_ROOT/bin:$PATH"


### PR DESCRIPTION
The unauthenticated git protocol is no longer supported.

https://github.blog/2021-09-01-improving-git-protocol-security-github/

Fixes #303