### PR TITLE
Update the Vagrantfile target OS to Ubuntu jammy

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure(2) do |config|
-  config.vm.box = 'ubuntu/bionic64'
+  config.vm.box = 'ubuntu/jammy64'
 
   config.vm.synced_folder "..", "/dotbot", mount_options: ["ro"]
 


### PR DESCRIPTION
This resolves VirtualBox 5.x/6.x Guest Additions incompatibilities that cause all of the unit tests to fail under VirtualBox 6.1.

Fixes #305