### PR TITLE
Fix Windows symlinks

### DIFF
--- a/dotbot/plugins/link.py
+++ b/dotbot/plugins/link.py
@@ -196,7 +196,10 @@ class Link(dotbot.Plugin):
         Returns the destination of the symbolic link.
         """
         path = os.path.expanduser(path)
-        return os.readlink(path)
+        path = os.readlink(path)
+        if sys.platform[:5] == "win32" and path[:4] == "\\\\?\\":
+            return path[4:]
+        return path
 
     def _exists(self, path):
         """

--- a/dotbot/plugins/link.py
+++ b/dotbot/plugins/link.py
@@ -4,7 +4,6 @@ import glob
 import shutil
 import dotbot
 import dotbot.util
-import subprocess
 
 
 class Link(dotbot.Plugin):


### PR DESCRIPTION
On Windows, `os.readlink(path)` returns UNC paths that start with `\\?\`.

The UNC prefix can simply be removed when running on Windows.

Fixes #307
