### PR TITLE
feat(shell): run shell command conditionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ fine-grained control.
 | `stdin` | Allow a command to read from standard input (default: false) |
 | `stdout` | Show a command's output from stdout (default: false) |
 | `stderr` | Show a command's error output from stderr (default: false) |
+| `if` | Run command if a condition is true (default: true) (optional) |
 
 Note that `quiet` controls whether the command (a string) is printed in log
 output, it does not control whether the output from running the command is
@@ -354,6 +355,19 @@ printed (that is controlled by `stdout` / `stderr`). When a command's `stdin` /
   -
     command: read fail
     stderr: true
+```
+
+##### Running shell command conditionally
+
+```yaml
+- shell:
+    - command: apt update && apt upgrade -y
+      if: lsb_release -i | grep -io 'debian'
+      description: Update APT package repository
+
+    - command: dnf update -y
+      if: lsb_release -i | grep -io 'fedora'
+      description: Update DNF package repository
 ```
 
 ### Clean

--- a/dotbot/plugins/shell.py
+++ b/dotbot/plugins/shell.py
@@ -36,6 +36,30 @@ class Shell(dotbot.Plugin):
                 stdout = item.get("stdout", stdout)
                 stderr = item.get("stderr", stderr)
                 quiet = item.get("quiet", quiet)
+
+                # run shell command if the 'if' key is present
+                # Ex:
+                # - shell:
+                #     - command: echo "This computer is a Mac"
+                #       if: uname -s | grep -i "Darwin"
+                #
+                # Ex: skipping shell command
+                # - shell:
+                #     - command: echo "skip this shell command"
+                #       if: false
+                if "if" in item:
+                    run_if_result = dotbot.util.shell_command(
+                        str(item["if"]),        # this to make sure python doesn't run it. Had a odd behaviour with having the value 'false'. Check Pull Request #321
+                        cwd=self._context.base_directory(),
+                        enable_stdin=False,
+                        enable_stdout=False,
+                        enable_stderr=stderr,
+                    )
+
+                    # if the condition to run the command is false,
+                    # skip running the command
+                    if run_if_result != 0:
+                        continue
             elif isinstance(item, list):
                 cmd = item[0]
                 msg = item[1] if len(item) > 1 else None


### PR DESCRIPTION
## what
- Run shell command conditionally (optional)
- Update README docs

## how
- the shell directive will check if the 'if' property is available.
  - If it is, it will run the command in 'if' property.
  - If the command results in a return 0 code or 'true', then the 'command' property will run.
  - If the condition to run the command is a non 0 code or 'false', the shell command won't run
- dotbot config example:
```yaml
- shell:
    - command: echo "this is running on a MacOS"
      if: uname -s | grep -i "Darwin"
```
- running shell command regardless
```yaml
- shell:
    - command: echo "This should run regardless"
```

- dotbot config example: skipping command if false
```yaml
- shell:
    - command: echo "This command should be skipped"
      if: false
```

## why
- can run the shell command conditionally
- can use multiple dotbot configs to run different OS
  - Ex: incorporating it in https://github.com/ecarlson94/dotbot-template

## where
- file changed in `./dotbot/plugins/shell.py`

## usage
Create dotbot config
```yaml
- shell:
    - command: echo "this is running on a MacOS"
      if: uname -s | grep -i "Darwin"
```

```yaml
- shell:
    - command: echo "This command should be skipped"
      if: false
```

```yaml
- shell:
    - command: apt update && apt upgrade -y
      if: lsb_release -i | grep -io 'debian'
      description: Update APT package repository

    - command: dnf update -y
      if: lsb_release -i | grep -io 'fedora'
      description: Update DNF package repository
```

# NOTE
- The reason to wrap the if command in string, is to prevent Python from interpreting it.
  - `str(item["if"]),`
  - https://github.com/Clumsy-Coder/dotbot/blob/25ef5d5a5fed1e2f95e57115dfdbc8ba67cfc93f/dotbot/plugins/shell.py#L52
  - Try it without wrapping it in strings
    - https://github.com/Clumsy-Coder/dotbot/blob/974156ccdecee05eb9544b0b21cc0351428ddd43/dotbot/plugins/shell.py#L51-L57
    - ```python
      run_if_result = dotbot.util.shell_command(
          item["if"],
          cwd=self._context.base_directory(),
          enable_stdin=False,
          enable_stdout=False,
          enable_stderr=stderr,
      )
      ```
    - Fails to run because error was thrown
      ```yaml
      - shell:
          - command: echo "This command should be skipped"
            if: false
      ```
    - Works if wrapping `false` in strings
      ```yaml
      - shell:
          - command: echo "This command should be skipped"
            if: "false"
      ```
    
