### PR TITLE
don't show command if `quiet: true` and description is not set

### DIFF
--- a/dotbot/plugins/shell.py
+++ b/dotbot/plugins/shell.py
@@ -42,10 +42,11 @@ class Shell(dotbot.Plugin):
             else:
                 cmd = item
                 msg = None
-            if msg is None:
+            if quiet:
+                if msg is not None:
+                    self._log.lowinfo("%s" % msg)
+            elif msg is None:
                 self._log.lowinfo(cmd)
-            elif quiet:
-                self._log.lowinfo("%s" % msg)
             else:
                 self._log.lowinfo("%s [%s]" % (msg, cmd))
             stdout = options.get("stdout", stdout)


### PR DESCRIPTION
## Why
I have a shell directive and only want to see the command's output. I set `quiet: true` and `stdout: true`. When I ran dotbot, It showed the command, which I think should not be the case.

Resolves #265 