### PR TITLE
Fix dispatcher when no plugins are given

### DIFF
--- a/dotbot/dispatcher.py
+++ b/dotbot/dispatcher.py
@@ -18,7 +18,10 @@ class Dispatcher(object):
     ):
         self._log = Messenger()
         self._setup_context(base_directory, options)
-        plugins = plugins or []
+        if plugins == None:
+            plugins = Plugin.__subclasses__()
+        else:
+            plugins = plugins or []
         self._plugins = [plugin(self._context) for plugin in plugins]
         self._only = only
         self._skip = skip

--- a/tests/dotbot_plugin_dispatch.py
+++ b/tests/dotbot_plugin_dispatch.py
@@ -1,0 +1,17 @@
+"""Test that a plugin can call dispatcher for subtasks.
+
+The plugin calls dispatch with his data.
+"""
+
+import os.path
+
+import dotbot
+
+
+class Dispatch(dotbot.Plugin):
+    def can_handle(self, directive):
+        return directive == "dispatch"
+
+    def handle(self, directive, data):
+        dispatcher = dotbot.dispatcher.Dispatcher(self._context.base_directory())
+        return dispatcher.dispatch(data)

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -1,0 +1,22 @@
+import os
+import shutil
+
+import pytest
+
+
+def test_plugin_dispatcher(capfd, home, dotfiles, run_dotbot):
+    """Verify that plugins can call dispatcher without explicitly specifying plugins."""
+
+    dotfiles.makedirs("plugins")
+    plugin_file = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "dotbot_plugin_dispatch.py"
+    )
+    shutil.copy(plugin_file, os.path.join(dotfiles.directory, "plugins", "dispatch.py"))
+    dotfiles.write_config(
+        [
+            {"dispatch": [{"create": ["~/a"]}]},
+        ]
+    )
+    run_dotbot("--plugin-dir", os.path.join(dotfiles.directory, "plugins"))
+
+    assert os.path.exists(os.path.join(home, "a"))


### PR DESCRIPTION
When any plugin is using the dispatcher for nested actions it should
pass all plugins again to avoid that any plugin as subtask would be
handled.
Currently this means a lot of plugins are broken because they don't pass
plugins to the dispatcher.

To fix this, take all Plugin subclasses when no plugin is given (we
should at least have the default plugins).