### PR TITLE
Add backup option to Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ mapped to extended configuration dictionaries.
 | `create` | When true, create parent directories to the link as needed. (default: false) |
 | `relink` | Removes the old target if it's a symlink (default: false) |
 | `force` | Force removes the old target, file or folder, and forces a new link (default: false) |
+| `backup-root` | In case of `force` or `relink` backup the old target to `backup-root` (default: no backup) |
 | `relative` | Use a relative path to the source when creating the symlink (default: false, absolute links) |
 | `canonicalize` | Resolve any symbolic links encountered in the source to symlink to the canonical path (default: true, real paths) |
 | `if` | Execute this in your `$SHELL` and only link if it is successful. |

--- a/dotbot/plugins/link.py
+++ b/dotbot/plugins/link.py
@@ -33,6 +33,7 @@ class Link(Plugin):
             canonical_path = defaults.get("canonicalize", defaults.get("canonicalize-path", True))
             force = defaults.get("force", False)
             relink = defaults.get("relink", False)
+            backup_root = defaults.get("backup-root", None)
             create = defaults.get("create", False)
             use_glob = defaults.get("glob", False)
             base_prefix = defaults.get("prefix", "")
@@ -48,6 +49,7 @@ class Link(Plugin):
                 )
                 force = source.get("force", force)
                 relink = source.get("relink", relink)
+                backup_root = source.get("backup-root", backup_root)
                 create = source.get("create", create)
                 use_glob = source.get("glob", use_glob)
                 base_prefix = source.get("prefix", base_prefix)
@@ -85,6 +87,7 @@ class Link(Plugin):
                             relative,
                             canonical_path,
                             force,
+                            backup_root,
                         )
                     success &= self._link(
                         glob_full_item,
@@ -107,7 +110,9 @@ class Link(Plugin):
                     self._log.warning("Nonexistent source %s -> %s" % (destination, path))
                     continue
                 if force or relink:
-                    success &= self._delete(path, destination, relative, canonical_path, force)
+                    success &= self._delete(
+                        path, destination, relative, canonical_path, force, backup_root
+                    )
                 success &= self._link(path, destination, relative, canonical_path, ignore_missing)
         if success:
             self._log.info("All links have been set up")

--- a/dotbot/plugins/link.py
+++ b/dotbot/plugins/link.py
@@ -246,7 +246,7 @@ class Link(Plugin):
                 self._log.lowinfo("Creating directory %s" % parent)
         return success
 
-    def _delete(self, source, path, relative, canonical_path, force):
+    def _delete(self, source, path, relative, canonical_path, force, backup_root):
         success = True
         source = os.path.join(self._context.base_directory(canonical_path=canonical_path), source)
         fullpath = os.path.abspath(os.path.expanduser(path))
@@ -256,8 +256,13 @@ class Link(Plugin):
             self._exists(path) and not self._is_link(path)
         ):
             removed = False
+            if backup_root:
+                backed_up = self._backup(path, backup_root)
             try:
-                if os.path.islink(fullpath):
+                if backup_root and not backed_up:
+                    self._log.warning("Skipping removal of %s due to failed backup" % path)
+                    success = False
+                elif os.path.islink(fullpath):
                     os.unlink(fullpath)
                     removed = True
                 elif force:

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -1037,6 +1037,26 @@ def test_link_relink_backups_symlink(home, dotfiles, run_dotbot):
         assert file.read() == "apple"
 
 
+def test_link_relink_aborts_on_failed_backup(home, dotfiles, run_dotbot):
+    """Verify relink is aborted if backup fails."""
+
+    dotfiles.write("f", "apple")
+    with open(os.path.join(home, "f"), "w") as file:
+        file.write("grape")
+    os.symlink(os.path.join(home, "f"), os.path.join(home, ".f"))
+    dotfiles.write("backup")
+
+    backup_root = os.path.join(dotfiles.directory, "backup")
+    dotfiles.write_config(
+        [{"link": {"~/.f": {"path": "f", "relink": True, "backup-root": backup_root}}}]
+    )
+    with pytest.raises(SystemExit):
+        run_dotbot()
+
+    with open(os.path.join(home, ".f"), "r") as file:
+        assert file.read() == "grape"
+
+
 def test_link_relink_relative_leaves_file(home, dotfiles, run_dotbot):
     """Verify relink relative does not incorrectly relink file."""
 

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -175,6 +175,32 @@ def test_link_force_overwrite_symlink(home, dotfiles, run_dotbot):
     assert os.path.isfile(os.path.join(home, ".dir", "f"))
 
 
+def test_link_force_overwrite_source(home, dotfiles, run_dotbot):
+    """Verify force overwrites a symlinked directory."""
+
+    os.symlink(home, os.path.join(home, ".link"))
+    with open(os.path.join(home, "file"), "w") as file:
+        file.write("")
+    os.mkdir(os.path.join(home, "dir"))
+    dotfiles.write("dir/f")
+
+    config = [
+        {
+            "link": {
+                "~/.link": {"path": "dir", "force": True},
+                "~/file": {"path": "dir", "force": True},
+                "~/dir": {"path": "dir", "force": True},
+            }
+        }
+    ]
+    dotfiles.write_config(config)
+    run_dotbot()
+
+    assert os.path.isfile(os.path.join(home, ".link", "f"))
+    assert os.path.isfile(os.path.join(home, "file", "f"))
+    assert os.path.isfile(os.path.join(home, "dir", "f"))
+
+
 def test_link_glob_1(home, dotfiles, run_dotbot):
     """Verify globbing works."""
 

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -277,6 +277,33 @@ def test_link_force_aborts_on_failed_backup(home, dotfiles, run_dotbot):
     assert os.path.isdir(os.path.join(home, "dir"))
 
 
+def test_no_backup_when_no_force_relink(home, dotfiles, run_dotbot):
+    """Verify backup is a no-op without an accompanying force or relink."""
+
+    os.symlink(home, os.path.join(home, ".link"))
+    with open(os.path.join(home, "file"), "w") as file:
+        file.write("apple")
+    os.mkdir(os.path.join(home, "dir"))
+    dotfiles.write("dir/f")
+
+    backup_root = os.path.join(dotfiles.directory, "backup")
+    config = [
+        {
+            "link": {
+                "~/.link": {"path": "dir", "backup-root": backup_root},
+                "~/file": {"path": "dir", "backup-root": backup_root},
+                "~/dir": {"path": "dir", "backup-root": backup_root},
+                "~/.new": {"path": "dir", "backup-root": backup_root},
+            }
+        }
+    ]
+    dotfiles.write_config(config)
+    with pytest.raises(SystemExit):
+        run_dotbot()
+
+    assert not os.path.exists(backup_root)
+
+
 def test_link_glob_1(home, dotfiles, run_dotbot):
     """Verify globbing works."""
 

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -1011,6 +1011,32 @@ def test_link_relink_overwrite_symlink(home, dotfiles, run_dotbot):
         assert file.read() == "apple"
 
 
+def test_link_relink_backups_symlink(home, dotfiles, run_dotbot):
+    """Verify relink backups symlinks."""
+
+    dotfiles.write("f", "apple")
+    with open(os.path.join(home, "f"), "w") as file:
+        file.write("grape")
+    os.symlink(os.path.join(home, "f"), os.path.join(home, ".f"))
+
+    backup_root = os.path.join(dotfiles.directory, "backup")
+    dotfiles.write_config(
+        [{"link": {"~/.f": {"path": "f", "relink": True, "backup-root": backup_root}}}]
+    )
+    run_dotbot()
+
+    backup_home = os.path.join(backup_root, home[1:])
+    assert os.path.isdir(backup_home)
+    dir_items = os.listdir(backup_home)
+    assert len(dir_items) == 1
+    backuped = os.path.join(backup_home, dir_items[0])
+    assert os.path.islink(backuped)
+    with open(backuped, "r") as file:
+        assert file.read() == "grape"
+    with open(os.path.join(home, ".f"), "r") as file:
+        assert file.read() == "apple"
+
+
 def test_link_relink_relative_leaves_file(home, dotfiles, run_dotbot):
     """Verify relink relative does not incorrectly relink file."""
 

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -201,6 +201,20 @@ def test_link_force_overwrite_source(home, dotfiles, run_dotbot):
     assert os.path.isfile(os.path.join(home, "dir", "f"))
 
 
+def test_backup_mirrors_absolute_path(home, dotfiles, run_dotbot):
+    """Verify backup path from backup dir is same as original path from root."""
+
+    os.symlink(home, os.path.join(home, ".f"))
+    dotfiles.write("f")
+
+    backup_root = os.path.join(dotfiles.directory, "backup")
+    config = [{"link": {"~/.f": {"path": "f", "force": True, "backup-root": backup_root}}}]
+    dotfiles.write_config(config)
+    run_dotbot()
+
+    assert os.path.isdir(os.path.join(backup_root, home[1:]))
+
+
 def test_link_force_backups_source(home, dotfiles, run_dotbot):
     """Verify force backups a symlinked directory."""
 


### PR DESCRIPTION
Adds a `backup-root` option to link.

- The root backup directory is determined by the `[defaults.]link.backup-root` option.
- The backup only activates when the `relink` and/or `force` options are set.
- If the root backup directory provided is not an absolute path it will be relative to the dot files directory.
- The backed up paths created inside the backup directory will mirror their original absolute paths.
- Duplication will be avoided by time stamps.
    - Timestamps will be added on the *file/dir* replaced.
    - Timestamps  will use ISO format.
- e.g.
    - `/home/marvin/.dots/backup/home/marvin/.bashrc.20230715T193010.013493`
    - `/home/marvin/.dots/backup/home/marvin/.ssh.20230715T193010.013512/`
- Tests:
    - Previously existing tests are not broken.
    - test_link_force_overwrite_source
    - test_link_force_backup_source
    - test_link_force_aborts_on_failed_backup
    - test_link_relink_backups_symlink
    - test_link_relink_aborts_on_failed_backup
    - test_no_backup_when_no_force_relink
    - test_backup_is_sequentially_differentiated
    - test_backup_mirrors_absolute_path

I apologize if this is irrelevant or out of place and will be thankful for any feedback.

Addresses #12
relates to #35
Addresses #36
Addresses #90
