### PR TITLE
Make Dispatcher a singleton after first instantiation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ import pytest
 import yaml
 
 import dotbot.cli
+import dotbot.dispatcher
 
 
 def get_long_path(path):
@@ -312,3 +313,9 @@ def run_dotbot(dotfiles):
             dotbot.cli.main()
 
     yield runner
+
+
+@pytest.fixture(autouse=True)
+def reset_current_dispatcher():
+    yield
+    dotbot.dispatcher.current_dispatcher = None

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -1,0 +1,22 @@
+import dotbot.dispatcher
+
+
+def test_dispatcher_instantiation(home, dotfiles, run_dotbot):
+    """Verify that the dispatcher caches itself as a singleton."""
+
+    assert dotbot.dispatcher.current_dispatcher is None
+
+    dotfiles.write_config([])
+    run_dotbot()
+
+    # Verify the dispatcher has been cached.
+    assert dotbot.dispatcher.current_dispatcher is not None
+
+    existing_id = id(dotbot.dispatcher.current_dispatcher)
+    new_instance = dotbot.dispatcher.Dispatcher("bogus")
+
+    # Verify the new and existing instances are the same.
+    assert existing_id == id(new_instance)
+
+    # Verify the singleton was not overridden.
+    assert existing_id == id(dotbot.dispatcher.current_dispatcher)


### PR DESCRIPTION
This allows plugins to re-instantiate the Dispatcher (or, now, use the instance cached in `current_dispatcher`) without knowing what plugins have been loaded by dotbot.

This fixes plugins that want to dispatch to other plugins.

Fixes #339
Fixes #357