### PR TITLE
Fix wrong pyyaml path

### DIFF
--- a/bin/dotbot
+++ b/bin/dotbot
@@ -32,7 +32,7 @@ def inject(lib_path):
     path = os.path.join(PROJECT_ROOT_DIRECTORY, 'lib', lib_path)
     sys.path.insert(0, path)
 
-inject('pyyaml/lib3')
+inject('pyyaml/lib')
 
 if os.path.exists(os.path.join(PROJECT_ROOT_DIRECTORY, 'dotbot')):
     if PROJECT_ROOT_DIRECTORY not in sys.path:


### PR DESCRIPTION
pyyaml 6.0.1 no longer use path `lib3`.