### PR TITLE
Support Python 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-20.04", "macos-latest"]
-        python: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.9"]
+        python: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.9"]
         include:
           - os: "windows-latest"
             python: "3.8"
@@ -22,6 +22,8 @@ jobs:
             python: "3.10"
           - os: "windows-latest"
             python: "3.11"
+          - os: "windows-latest"
+            python: "3.12"
     runs-on: ${{ matrix.os }}
     name: "Test: Python ${{ matrix.python }} on ${{ matrix.os }}"
     steps:
@@ -31,6 +33,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
       - name: "Install dependencies"
         run: |
           python -m pip install --upgrade pip setuptools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,8 @@ exclude = '''
  | lib
  )/
 '''
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "error",
+]

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Utilities",
     ],
     keywords="dotfiles",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,7 +219,10 @@ def root(standardize_tmp):
     finally:
         [patch.stop() for patch in patches]
         os.chdir(current_working_directory)
-        rmtree(current_root, onerror=rmtree_error_handler)
+        if sys.version_info >= (3, 12):
+            rmtree(current_root, onexc=rmtree_error_handler)
+        else:
+            rmtree(current_root, onerror=rmtree_error_handler)
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 ; All older versions, and PyPy, lack full symlink support.
 envlist =
     coverage_erase
-    py{38, 39, 310, 311}-all_platforms
+    py{38, 39, 310, 311, 312}-all_platforms
     py{36, 37}-most_platforms
     pypy3-most_platforms
     coverage_report
@@ -64,6 +64,7 @@ python =
     3.9: py39-all_platforms
     3.10: py310-all_platforms
     3.11: py311-all_platforms
+    3.12: py312-all_platforms
 
     ; Run on most platforms (Linux and Mac)
     pypy-3.9: pypy3-most_platforms


### PR DESCRIPTION
All tests pass under Python 3.12 already, but the test suite was using a `shutil.rmtree` option, `onerror`, that Python 3.12 introduced a replacement for (`onexc`) and simultaneously deprecated.

This is addressed, pytest is now configured to escalate warnings into errors, and the test suite -- and CI -- have been updated to include Python 3.12 in their runs.