### PR TITLE
Use pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,33 @@
+# Run `pre-commit autoupdate` to update tool versions.
+# Note that pre-commit.ci can update hook versions automatically.
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks.git
+    rev: v4.4.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.10.1
+    hooks:
+      - id: pyupgrade
+        name: "Enforce Python 3.6 idioms"
+        args: [--py36-plus]
+
+  - repo: https://github.com/psf/black
+    rev: 23.9.0
+    hooks:
+      - id: black
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
+    rev: 2.7.2
+    hooks:
+      - id: editorconfig-checker

--- a/dotbot/cli.py
+++ b/dotbot/cli.py
@@ -99,7 +99,7 @@ def main():
                 hash_msg = " (git %s)" % git_hash[:10]
             except (OSError, subprocess.CalledProcessError):
                 hash_msg = ""
-            print("Dotbot version %s%s" % (dotbot.__version__, hash_msg))
+            print(f"Dotbot version {dotbot.__version__}{hash_msg}")
             exit(0)
         if options.super_quiet:
             log.set_level(Level.WARNING)

--- a/dotbot/messenger/messenger.py
+++ b/dotbot/messenger/messenger.py
@@ -16,7 +16,7 @@ class Messenger(metaclass=Singleton):
 
     def log(self, level, message):
         if level >= self._level:
-            print("%s%s%s" % (self._color(level), message, self._reset()))
+            print(f"{self._color(level)}{message}{self._reset()}")
 
     def debug(self, message):
         self.log(Level.DEBUG, message)

--- a/dotbot/plugins/clean.py
+++ b/dotbot/plugins/clean.py
@@ -57,10 +57,10 @@ class Clean(Plugin):
                 if sys.platform[:5] == "win32" and points_at.startswith("\\\\?\\"):
                     points_at = points_at[4:]
                 if self._in_directory(path, self._context.base_directory()) or force:
-                    self._log.lowinfo("Removing invalid link %s -> %s" % (path, points_at))
+                    self._log.lowinfo(f"Removing invalid link {path} -> {points_at}")
                     os.remove(path)
                 else:
-                    self._log.lowinfo("Link %s -> %s not removed." % (path, points_at))
+                    self._log.lowinfo(f"Link {path} -> {points_at} not removed.")
         return True
 
     def _in_directory(self, path, directory):

--- a/dotbot/plugins/create.py
+++ b/dotbot/plugins/create.py
@@ -45,7 +45,7 @@ class Create(Plugin):
     def _create(self, path, mode):
         success = True
         if not self._exists(path):
-            self._log.debug("Trying to create path %s with mode %o" % (path, mode))
+            self._log.debug(f"Trying to create path {path} with mode {mode:o}")
             try:
                 self._log.lowinfo("Creating path %s" % path)
                 os.makedirs(path, mode)

--- a/dotbot/plugins/link.py
+++ b/dotbot/plugins/link.py
@@ -103,7 +103,7 @@ class Link(Plugin):
                     # want to remove the original (this is tested by
                     # link-force-leaves-when-nonexistent.bash)
                     success = False
-                    self._log.warning("Nonexistent source %s -> %s" % (destination, path))
+                    self._log.warning(f"Nonexistent source {destination} -> {path}")
                     continue
                 if force or relink:
                     success &= self._delete(path, destination, relative, canonical_path, force)
@@ -254,9 +254,7 @@ class Link(Plugin):
             and self._is_link(link_name)
             and self._link_destination(link_name) != source
         ):
-            self._log.warning(
-                "Invalid link %s -> %s" % (link_name, self._link_destination(link_name))
-            )
+            self._log.warning(f"Invalid link {link_name} -> {self._link_destination(link_name)}")
         # we need to use absolute_source below because our cwd is the dotfiles
         # directory, and if source is relative, it will be relative to the
         # destination directory
@@ -264,23 +262,21 @@ class Link(Plugin):
             try:
                 os.symlink(source, destination)
             except OSError:
-                self._log.warning("Linking failed %s -> %s" % (link_name, source))
+                self._log.warning(f"Linking failed {link_name} -> {source}")
             else:
-                self._log.lowinfo("Creating link %s -> %s" % (link_name, source))
+                self._log.lowinfo(f"Creating link {link_name} -> {source}")
                 success = True
         elif self._exists(link_name) and not self._is_link(link_name):
             self._log.warning("%s already exists but is a regular file or directory" % link_name)
         elif self._is_link(link_name) and self._link_destination(link_name) != source:
-            self._log.warning(
-                "Incorrect link %s -> %s" % (link_name, self._link_destination(link_name))
-            )
+            self._log.warning(f"Incorrect link {link_name} -> {self._link_destination(link_name)}")
         # again, we use absolute_source to check for existence
         elif not self._exists(absolute_source):
             if self._is_link(link_name):
-                self._log.warning("Nonexistent source %s -> %s" % (link_name, source))
+                self._log.warning(f"Nonexistent source {link_name} -> {source}")
             else:
-                self._log.warning("Nonexistent source for %s : %s" % (link_name, source))
+                self._log.warning(f"Nonexistent source for {link_name} : {source}")
         else:
-            self._log.lowinfo("Link exists %s -> %s" % (link_name, source))
+            self._log.lowinfo(f"Link exists {link_name} -> {source}")
             success = True
         return success

--- a/dotbot/plugins/shell.py
+++ b/dotbot/plugins/shell.py
@@ -46,7 +46,7 @@ class Shell(Plugin):
             elif msg is None:
                 self._log.lowinfo(cmd)
             else:
-                self._log.lowinfo("%s [%s]" % (msg, cmd))
+                self._log.lowinfo(f"{msg} [{cmd}]")
             stdout = options.get("stdout", stdout)
             stderr = options.get("stderr", stderr)
             ret = shell_command(

--- a/dotbot/util/common.py
+++ b/dotbot/util/common.py
@@ -4,7 +4,7 @@ import subprocess
 
 
 def shell_command(command, cwd=None, enable_stdin=False, enable_stdout=False, enable_stderr=False):
-    with open(os.devnull, "w") as devnull_w, open(os.devnull, "r") as devnull_r:
+    with open(os.devnull, "w") as devnull_w, open(os.devnull) as devnull_r:
         stdin = None if enable_stdin else devnull_r
         stdout = None if enable_stdout else devnull_w
         stderr = None if enable_stderr else devnull_w

--- a/dotbot/util/singleton.py
+++ b/dotbot/util/singleton.py
@@ -3,5 +3,5 @@ class Singleton(type):
 
     def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:
-            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+            cls._instances[cls] = super().__call__(*args, **kwargs)
         return cls._instances[cls]

--- a/dotbot/util/string.py
+++ b/dotbot/util/string.py
@@ -1,4 +1,4 @@
 def indent_lines(string, amount=2, delimiter="\n"):
     whitespace = " " * amount
-    sep = "%s%s" % (delimiter, whitespace)
-    return "%s%s" % (whitespace, sep.join(string.split(delimiter)))
+    sep = f"{delimiter}{whitespace}"
+    return f"{whitespace}{sep.join(string.split(delimiter))}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,7 +188,7 @@ def root(standardize_tmp):
 
         # These values must be passed to a separate function
         # to ensure the variable closures work correctly.
-        function_path = "{0}.{1}".format(module.__name__, function_name)
+        function_path = f"{module.__name__}.{function_name}"
         function = getattr(module, function_name)
         wrapped = wrap_function(function, function_path, arg_index, kwarg_key, current_root)
         patches.append(mock.patch(function_path, wrapped))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -140,7 +140,7 @@ def test_plugin_loading_file(home, dotfiles, run_dotbot):
     dotfiles.write_config([{"plugin_file": "~"}])
     run_dotbot("--plugin", os.path.join(dotfiles.directory, "file.py"))
 
-    with open(os.path.join(home, "flag"), "r") as file:
+    with open(os.path.join(home, "flag")) as file:
         assert file.read() == "file plugin loading works"
 
 
@@ -155,7 +155,7 @@ def test_plugin_loading_directory(home, dotfiles, run_dotbot):
     dotfiles.write_config([{"plugin_directory": "~"}])
     run_dotbot("--plugin-dir", os.path.join(dotfiles.directory, "plugins"))
 
-    with open(os.path.join(home, "flag"), "r") as file:
+    with open(os.path.join(home, "flag")) as file:
         assert file.read() == "directory plugin loading works"
 
 

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -47,7 +47,7 @@ def test_link_default_source(root, home, dst, include_force, dotfiles, run_dotbo
     dotfiles.write_config(config)
     run_dotbot()
 
-    with open(os.path.abspath(os.path.expanduser(dst)), "r") as file:
+    with open(os.path.abspath(os.path.expanduser(dst))) as file:
         assert file.read() == "apple"
 
 
@@ -61,7 +61,7 @@ def test_link_environment_user_expansion_target(home, dotfiles, run_dotbot):
     dotfiles.write_config([{"link": {target: src}}])
     run_dotbot()
 
-    with open(os.path.abspath(os.path.expanduser(target)), "r") as file:
+    with open(os.path.abspath(os.path.expanduser(target))) as file:
         assert file.read() == "apple"
 
 
@@ -75,7 +75,7 @@ def test_link_environment_variable_expansion_source(monkeypatch, root, home, dot
     dotfiles.write_config([{"link": {target: src}}])
     run_dotbot()
 
-    with open(os.path.abspath(os.path.expanduser(target)), "r") as file:
+    with open(os.path.abspath(os.path.expanduser(target))) as file:
         assert file.read() == "grape"
 
 
@@ -91,7 +91,7 @@ def test_link_environment_variable_expansion_source_extended(
     dotfiles.write_config([{"link": {target: {"path": src, "relink": True}}}])
     run_dotbot()
 
-    with open(os.path.abspath(os.path.expanduser(target)), "r") as file:
+    with open(os.path.abspath(os.path.expanduser(target))) as file:
         assert file.read() == "grape"
 
 
@@ -122,9 +122,9 @@ def test_link_environment_variable_expansion_target(monkeypatch, root, home, dot
     dotfiles.write_config(config)
     run_dotbot()
 
-    with open(os.path.join(home, ".config", "g"), "r") as file:
+    with open(os.path.join(home, ".config", "g")) as file:
         assert file.read() == "apple"
-    with open(os.path.join(home, "$PEAR"), "r") as file:
+    with open(os.path.join(home, "$PEAR")) as file:
         assert file.read() == "grape"
 
 
@@ -136,7 +136,7 @@ def test_link_environment_variable_unset(monkeypatch, root, home, dotfiles, run_
     dotfiles.write_config([{"link": {"~/f": "$ORANGE"}}])
     run_dotbot()
 
-    with open(os.path.join(home, "f"), "r") as file:
+    with open(os.path.join(home, "f")) as file:
         assert file.read() == "apple"
 
 
@@ -759,7 +759,7 @@ def test_link_leaves_file(home, dotfiles, run_dotbot):
     with pytest.raises(SystemExit):
         run_dotbot()
 
-    with open(os.path.join(home, ".f"), "r") as file:
+    with open(os.path.join(home, ".f")) as file:
         assert file.read() == "grape"
 
 
@@ -880,7 +880,7 @@ def test_link_relink_leaves_file(home, dotfiles, run_dotbot):
     dotfiles.write_config([{"link": {"~/.f": {"path": "f", "relink": True}}}])
     with pytest.raises(SystemExit):
         run_dotbot()
-    with open(os.path.join(home, ".f"), "r") as file:
+    with open(os.path.join(home, ".f")) as file:
         assert file.read() == "grape"
 
 
@@ -893,7 +893,7 @@ def test_link_relink_overwrite_symlink(home, dotfiles, run_dotbot):
     os.symlink(os.path.join(home, "f"), os.path.join(home, ".f"))
     dotfiles.write_config([{"link": {"~/.f": {"path": "f", "relink": True}}}])
     run_dotbot()
-    with open(os.path.join(home, ".f"), "r") as file:
+    with open(os.path.join(home, ".f")) as file:
         assert file.read() == "apple"
 
 
@@ -944,7 +944,7 @@ def test_link_defaults_1(home, dotfiles, run_dotbot):
     with pytest.raises(SystemExit):
         run_dotbot()
 
-    with open(os.path.join(home, ".f"), "r") as file:
+    with open(os.path.join(home, ".f")) as file:
         assert file.read() == "grape"
 
 
@@ -963,5 +963,5 @@ def test_link_defaults_2(home, dotfiles, run_dotbot):
     )
     run_dotbot()
 
-    with open(os.path.join(home, ".f"), "r") as file:
+    with open(os.path.join(home, ".f")) as file:
         assert file.read() == "apple"

--- a/tests/test_noop.py
+++ b/tests/test_noop.py
@@ -5,9 +5,9 @@ import pytest
 
 def test_success(root):
     path = os.path.join(root, "abc.txt")
-    with open(path, "wt") as f:
+    with open(path, "w") as f:
         f.write("hello")
-    with open(path, "rt") as f:
+    with open(path) as f:
         assert f.read() == "hello"
 
 

--- a/tests/test_shim.py
+++ b/tests/test_shim.py
@@ -45,5 +45,5 @@ def test_shim(root, home, dotfiles, run_dotbot):
     subprocess.check_call(args, env=env, cwd=dotfiles.directory)
 
     assert os.path.islink(os.path.join(home, ".foo"))
-    with open(os.path.join(home, ".foo"), "r") as file:
+    with open(os.path.join(home, ".foo")) as file:
         assert file.read() == "pear"


### PR DESCRIPTION
git pre-commit hooks can catch linting issues on developer PCs before they're ever committed to the repo. [pre-commit](https://pre-commit.com/) is a widely-used tool that allows projects to specify all of the linters they want to run before each commit.

This PR introduces a pre-commit config that will enforce standard text linting; black, isort, and editorconfig linting; and idiomatic Python 3.6+ syntax.

* Developers with the pre-commit tool installed can simply run `pre-commit install` in the dotbot repo, and from that point forward git will run the tool prior to each commit so the files are linted and auto-fixed.
* The dotbot repo can be registered with the [pre-commit.ci](https://pre-commit.ci/) service so that it auto-checks -- and, by default, autofixes! -- incoming PRs. It will also open PRs to keep the pre-commit hook versions updated on a regular basis. _I STRONGLY recommend doing this!_