### PR TITLE
Add backup option to link action

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,19 +175,20 @@ Link commands support an optional extended configuration. In this type of
 configuration, instead of specifying source locations directly, targets are
 mapped to extended configuration dictionaries.
 
-| Parameter | Explanation |
-| --- | --- |
-| `path` | The source for the symlink, the same as in the shortcut syntax (default: null, automatic (see below)) |
-| `create` | When true, create parent directories to the link as needed. (default: false) |
-| `relink` | Removes the old target if it's a symlink (default: false) |
-| `force` | Force removes the old target, file or folder, and forces a new link (default: false) |
-| `relative` | Use a relative path to the source when creating the symlink (default: false, absolute links) |
-| `canonicalize` | Resolve any symbolic links encountered in the source to symlink to the canonical path (default: true, real paths) |
-| `if` | Execute this in your `$SHELL` and only link if it is successful. |
-| `ignore-missing` | Do not fail if the source is missing and create the link anyway (default: false) |
-| `glob` | Treat `path` as a glob pattern, expanding patterns referenced below, linking all *files* matched. (default: false) |
-| `exclude` | Array of glob patterns to remove from glob matches. Uses same syntax as `path`. Ignored if `glob` is `false`. (default: empty, keep all matches) |
-| `prefix` | Prepend prefix prefix to basename of each file when linked, when `glob` is `true`. (default: '') |
+| Parameter        | Explanation                                                                                                                                      |
+|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| `path`           | The source for the symlink, the same as in the shortcut syntax (default: null, automatic (see below))                                            |
+| `create`         | When true, create parent directories to the link as needed. (default: false)                                                                     |
+| `relink`         | Removes the old target if it's a symlink (default: false)                                                                                        |
+| `force`          | Force removes the old target, file or folder, and forces a new link (default: false)                                                             |
+| `backup`         | Backup existing files/directories if they exist, creating a backup with suffix `.dotbot-backup (default: false)                                  |
+| `relative`       | Use a relative path to the source when creating the symlink (default: false, absolute links)                                                     |
+| `canonicalize`   | Resolve any symbolic links encountered in the source to symlink to the canonical path (default: true, real paths)                                |
+| `if`             | Execute this in your `$SHELL` and only link if it is successful.                                                                                 |
+| `ignore-missing` | Do not fail if the source is missing and create the link anyway (default: false)                                                                 |
+| `glob`           | Treat `path` as a glob pattern, expanding patterns referenced below, linking all *files* matched. (default: false)                               |
+| `exclude`        | Array of glob patterns to remove from glob matches. Uses same syntax as `path`. Ignored if `glob` is `false`. (default: empty, keep all matches) |
+| `prefix`         | Prepend prefix prefix to basename of each file when linked, when `glob` is `true`. (default: '')                                                 |
 
 When `glob: True`, Dotbot uses [glob.glob](https://docs.python.org/3/library/glob.html#glob.glob) to resolve glob paths, expanding Unix shell-style wildcards, which are **not** the same as regular expressions; Only the following are expanded:
 

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -175,6 +175,76 @@ def test_link_force_overwrite_symlink(home, dotfiles, run_dotbot):
     assert os.path.isfile(os.path.join(home, ".dir", "f"))
 
 
+def test_backup_is_created_if_destination_exists(home, dotfiles, run_dotbot):
+    """Verify that the backup directory is created if destination exists."""
+
+    os.mkdir(os.path.join(home, ".dir"))
+    dotfiles.write("dir")
+
+    config = [{"link": {"~/.dir": {"path": "dir", "backup": True}}}]
+    dotfiles.write_config(config)
+    run_dotbot()
+
+    assert os.path.exists(os.path.join(home, ".dir.dotbot-backup"))
+
+
+def test_backup_file_is_created_if_destination_exists(home, dotfiles, run_dotbot):
+    """Verify that a backup file is created if destination exists."""
+
+    open(os.path.join(home, ".file"), "a").close()
+    dotfiles.write("file")
+
+    config = [{"link": {"~/.file": {"path": "file", "backup": True}}}]
+    dotfiles.write_config(config)
+    run_dotbot()
+
+    assert os.path.exists(os.path.join(home, ".file.dotbot-backup"))
+
+
+def test_backup_file_not_created_if_link(home, dotfiles, run_dotbot):
+    """Verify that a backup file isn't created if destination is a symlink."""
+
+    open(os.path.join(home, "file"), "a").close()
+    dotfiles.write("file")
+    os.symlink(os.path.join(home, "file"), os.path.join(home, ".file"))
+
+    config = [{"link": {"~/.file": {"path": "file", "backup": True}}}]
+    dotfiles.write_config(config)
+    with pytest.raises(SystemExit):
+        run_dotbot()
+
+    assert not os.path.exists(os.path.join(home, ".file.dotbot-backup"))
+
+
+def test_backup_file_not_created_if_force(home, dotfiles, run_dotbot):
+    """Verify that a backup file is created while using force option."""
+
+    open(os.path.join(home, ".file"), "a").close()
+    dotfiles.write("file")
+
+    config = [{"link": {"~/.file": {"path": "file", "backup": True, "force": True}}}]
+    dotfiles.write_config(config)
+    run_dotbot()
+
+    assert not os.path.exists(os.path.join(home, ".file.dotbot-backup"))
+
+
+def test_backup_error_if_dest_already_exists(home, dotfiles, run_dotbot):
+    """Verify an error is thrown if the backup already exists."""
+
+    os.mkdir(os.path.join(home, ".dir"))
+    os.mkdir(os.path.join(home, ".dir.dotbot-backup"))
+    open(os.path.join(home, ".dir.dotbot-backup", "f"), "a").close()
+    dotfiles.write("dir")
+
+    config = [{"link": {"~/.dir": {"path": "dir", "backup": True}}}]
+    dotfiles.write_config(config)
+    with pytest.raises(SystemExit):
+        run_dotbot()
+
+    assert os.path.exists(os.path.join(home, ".dir.dotbot-backup", "f"))
+
+
 def test_link_glob_1(home, dotfiles, run_dotbot):
     """Verify globbing works."""
 


### PR DESCRIPTION
Added a backup option to the link action, an option which defaults to false. 
If backup is set to true, existing files/directories will be backed up by renaming the file on the format 
`<original-filename>.dotbot-backup`.

This is useful for distributions where for example `.bashrc` is created during installation with sane defaults and you don't want to manually back them up.

- Added option to plugin
- Added unit tests
- Added information about option in README + fixed formatting of options table