### PR TITLE
Master

### DIFF
--- a/dotbot/cli.py
+++ b/dotbot/cli.py
@@ -130,7 +130,9 @@ def main():
             plugin_paths.append(plugin_path)
         for plugin_path in plugin_paths:
             abspath = os.path.abspath(plugin_path)
-            plugins.extend(module.load(abspath))
+            plugins_set = set(plugins)
+            plugins_set.update(module.load(abspath))
+            plugins = list(plugins_set)
         if not options.config_file:
             log.error("No configuration file specified")
             exit(1)


### PR DESCRIPTION
There is an interesting side-effect behavior of the 'fixes' for the Dispatcher recently committed. When an external plug-in is loaded, the cli creates a list of modules that just appends duplicates of the modules to the master-list. So, if the 4 main modules are already loaded, when the cli code gets to the command-line supplied directories, the logic in `module` appends them to the module that `load` is supposed to be loading. 

The net result is, after the pass through the plugin-libs, there are multiple copies of, say, `Link` `Shell` and friends. If you're adding 1 plugin, there are now 9 in the list - 2x 4 + your 1. 

This isn't too much of a problem _except_ logic further down the trail creates tasks for each instance of plugin. So you'll see your `Links` being done twice, etc. If you add, say, 3 plugins, you'll have your `Links` done 4x.

So, this simply does a set-merge to the list of modules to keep the redundancy down. I'm sure there is a better fix downstream but 1) I don't quite get what's going on in module.load to keep the redundancy down and 2) haven't gone to look at how the Dispatcher tasks are set up. 

Note that, some of the 'if' logic plugins have a 'loader' that further redundantly creates moduile lists, so I _think_ the right fix is somewhere in module.load, but I'm too tired right now and there's a student impatiently standing in my office. 