### PR TITLE
Fix missing config option in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ When using glob with the `exclude:` option, the paths in the exclude paths shoul
       if: '[ `uname` = Darwin ]'
       path: hammerspoon
     ~/.config/:
+      glob: true
       path: dotconf/config/**
     ~/:
       glob: true


### PR DESCRIPTION
I used the example highlighted in the PR, and it didn't work. On looking at the docs more closely, it says:

```
When glob: True, Dotbot uses [glob.glob](https://docs.python.org/3/library/glob.html#glob.glob) to resolve glob paths, expanding Unix shell-style wildcards, which are not the same as regular expressions; Only the following are expanded:
```

I took this to mean that `glob: true` _must_ be used if you want glob patterns to be expanded. Once I did that, everything worked as it should have.

So I think the example is just missing this option and thought I'd submit this PR to fix it.