### PR TITLE
Fix bug dispatching by dublicate plugins

### DIFF
--- a/dotbot/dispatcher.py
+++ b/dotbot/dispatcher.py
@@ -19,7 +19,7 @@ class Dispatcher:
         self._log = Messenger()
         self._setup_context(base_directory, options)
         plugins = plugins or []
-        self._plugins = [plugin(self._context) for plugin in plugins]
+        self._plugins = [plugin(self._context) for plugin in set(plugins)]
         self._only = only
         self._skip = skip
         self._exit = exit_on_failure


### PR DESCRIPTION
Dotbot performs some monkeypatch during loading, where it scans plugin modules and collects every class that inherits from the `Plugin` interface. This makes it easy to collect the same class objects.

Plugins such as [if](https://github.com/wonderbeyond/dotbot-if), [ifarch](https://github.com/ryansch/dotbot-ifarch) and [ifplatform](https://github.com/johnlettman/dotbot-ifhostname) contain the following line of code:
`from dotbot.plugins import Clean, Create, Link, Shell`
This line is sufficient to collect duplicate plugins and dispatch the same configuration instructions twice.

See:
https://github.com/ssbanerje/dotbot-ifplatform/pull/4#issuecomment-1532112176
https://github.com/anishathalye/dotbot/pull/351