### PR TITLE
Add a Dependabot config to maintain GitHub action versions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
If accepted, Dependabot will scan the repo for GitHub action version updates once per month and submit a single PR for any actions that have received updates.

Since the repo only pins to major versions (like `actions/checkout@v4`), this will probably be a small number of PRs per year. Nevertheless, it will help reduce maintenance burden as actions are updated and old versions are deprecated.