### PR TITLE
Add ability to pass multiple config files

### DIFF
--- a/src/dotbot/cli.py
+++ b/src/dotbot/cli.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 import sys
 from argparse import ArgumentParser, RawTextHelpFormatter
-from typing import Any
+from typing import Any, List
 
 import dotbot
 from dotbot.config import ConfigReader, ReadingError
@@ -24,7 +24,9 @@ def add_options(parser: ArgumentParser) -> None:
         help="enable verbose output\n" "-v: typical verbose\n" "-vv: also, set shell commands stderr/stdout to true",
     )
     parser.add_argument("-d", "--base-directory", help="execute commands from within BASEDIR", metavar="BASEDIR")
-    parser.add_argument("-c", "--config-file", help="run commands given in CONFIGFILE", metavar="CONFIGFILE")
+    parser.add_argument(
+        "-c", "--config-file", help="run commands given in CONFIGFILE", metavar="CONFIGFILE", action="append"
+    )
     parser.add_argument(
         "-p",
         "--plugin",
@@ -57,8 +59,8 @@ def add_options(parser: ArgumentParser) -> None:
     )
 
 
-def read_config(config_file: str) -> Any:
-    reader = ConfigReader(config_file)
+def read_config(config_files: List[str]) -> Any:
+    reader = ConfigReader(config_files)
     return reader.get_config()
 
 
@@ -127,8 +129,8 @@ def main() -> None:
         if options.base_directory:
             base_directory = os.path.abspath(options.base_directory)
         else:
-            # default to directory of config file
-            base_directory = os.path.dirname(os.path.abspath(options.config_file))
+            # default to directory of first config file
+            base_directory = os.path.dirname(os.path.abspath(options.config_file[0]))
         os.chdir(base_directory)
         _all_plugins[:] = plugins  # for backwards compatibility, see dispatcher.py
         dispatcher = Dispatcher(

--- a/src/dotbot/config.py
+++ b/src/dotbot/config.py
@@ -1,6 +1,7 @@
 import json
 import os.path
-from typing import Any
+from functools import reduce
+from typing import Any, List
 
 import yaml
 
@@ -8,8 +9,15 @@ from dotbot.util import string
 
 
 class ConfigReader:
-    def __init__(self, config_file_path: str):
-        self._config = self._read(config_file_path)
+    _config: List[Any]
+
+    def __init__(self, config_file_paths: List[str]):
+        # concatenate all config files
+        self._config = reduce(
+            lambda a, b: a + (b or []),
+            [self._read(p) for p in config_file_paths],
+            [],  # initial
+        )
 
     def _read(self, config_file_path: str) -> Any:
         try:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,3 +37,19 @@ def test_json_tabs(home: str, dotfiles: Dotfiles, run_dotbot: Callable[..., None
     run_dotbot("-c", os.path.join(dotfiles.directory, "config.json"), custom=True)
 
     assert os.path.isdir(os.path.join(home, "d"))
+
+
+def test_multiple_config(home: str, dotfiles: Dotfiles, run_dotbot: Callable[..., None]) -> None:
+    """Verify empty configs work."""
+
+    dotfiles.write("config1.json", json.dumps([{"create": ["~/d1"]}]))
+    dotfiles.write("config2.json", json.dumps([{"create": ["~/d2"]}]))
+
+    run_dotbot(
+        "-c", os.path.join(dotfiles.directory, "config1.json"),
+        "-c", os.path.join(dotfiles.directory, "config2.json"),
+        custom=True,
+    )
+
+    assert os.path.isdir(os.path.join(home, "d1"))
+    assert os.path.isdir(os.path.join(home, "d2"))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,7 +40,7 @@ def test_json_tabs(home: str, dotfiles: Dotfiles, run_dotbot: Callable[..., None
 
 
 def test_multiple_config(home: str, dotfiles: Dotfiles, run_dotbot: Callable[..., None]) -> None:
-    """Verify empty configs work."""
+    """Verify that passing multiple configs works."""
 
     dotfiles.write("config1.json", json.dumps([{"create": ["~/d1"]}]))
     dotfiles.write("config2.json", json.dumps([{"create": ["~/d2"]}]))


### PR DESCRIPTION
This commit adds the ability to pass multiple config files as command line arguments:

```bash
./bin/dotbot -c config_generic.yaml -c config_platform_specific.yaml
```

The config files are first concatenated in the order they are passed, and then the rest of
the dotbot code proceeds as it already exists. This felt like the least-intrusive way to
implement the feature, but happy to modify it if you see a better path.

Thanks! Awesome project you have here!
