### PR TITLE
Typing for plugins

### DIFF
--- a/src/dotbot/plugin.py
+++ b/src/dotbot/plugin.py
@@ -9,8 +9,8 @@ class Plugin:
     Abstract base class for commands that process directives.
     """
 
-    _log: Messenger
     _context: Context
+    _log: Messenger
     supports_dry_run: bool = False  # plugins must explicitly declare support for dry-run mode
 
     def __init__(self, context: Context):


### PR DESCRIPTION
* Non-final classes should have type annotation (basedpyright rule `reportUnannotatedClassAttribute`)
* Inherited plugins know type of `self._log` etc

I think the `supports_dry_run` is a ClassVar?