### PR TITLE
fix: guard against missing command key and empty list in shell plugin

### DIFF
--- a/src/dotbot/plugins/shell.py
+++ b/src/dotbot/plugins/shell.py
@@ -33,6 +33,10 @@ class Shell(Plugin):
             stderr = defaults.get("stderr", False)
             quiet = defaults.get("quiet", False)
             if isinstance(item, dict):
+                if "command" not in item:
+                    self._log.error(f"Missing 'command' key in shell item: {item}")
+                    success = False
+                    continue
                 cmd = item["command"]
                 msg = item.get("description", None)
                 stdin = item.get("stdin", stdin)
@@ -40,6 +44,10 @@ class Shell(Plugin):
                 stderr = item.get("stderr", stderr)
                 quiet = item.get("quiet", quiet)
             elif isinstance(item, list):
+                if not item:
+                    self._log.error("Empty list in shell items")
+                    success = False
+                    continue
                 cmd = item[0]
                 msg = item[1] if len(item) > 1 else None
             else:


### PR DESCRIPTION
## Bug 1: KeyError when shell item dict lacks command key

**File:** `src/dotbot/plugins/shell.py` line 36

**Problem:** The shell plugin accesses `item["command"]` directly without checking if the key exists. A dotbot config with a dict entry missing the required `command` key crashes with `KeyError`.

**Root Cause:**
```python
cmd = item["command"]  # KeyError if key missing
```

**Fix:** Check for key presence and emit a descriptive error before accessing.

---

## Bug 2: IndexError on empty list shell item

**File:** `src/dotbot/plugins/shell.py` line 43

**Problem:** A shell config entry that is an empty list `[]` causes `item[0]` to raise `IndexError`.

**Root Cause:**
```python
cmd = item[0]  # IndexError if item == []
```

**Fix:** Guard against empty list with an early continue.

---

## Impact
Both bugs cause dotbot to crash on malformed config entries. The fix degrades gracefully with a clear error message and continues processing remaining commands.